### PR TITLE
Introduce ClientVersion to request protos

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,6 +6,10 @@ android {
         vectorDrawables.useSupportLibrary = true
         consumerProguardFiles 'proguard-rules.txt'
         project.archivesBaseName = 'openyolo-api'
+
+        buildConfigField('String', 'clientVersionMajor', rootProject.ext.versionMajor)
+        buildConfigField('String', 'clientVersionMinor', rootProject.ext.versionMinor)
+        buildConfigField('String', 'clientVersionPatch', rootProject.ext.versionPatch)
     }
 }
 

--- a/bbq/build.gradle
+++ b/bbq/build.gradle
@@ -4,7 +4,15 @@ apply from:'../config/android-common.gradle'
 apply from:'../config/protobuf.gradle'
 apply from:'../config/third-party.gradle'
 
-android.defaultConfig.project.archivesBaseName = 'bbq'
+android {
+    defaultConfig {
+        project.archivesBaseName = 'bbq'
+
+        buildConfigField('String', 'bbqVersionMajor', rootProject.ext.versionMajor)
+        buildConfigField('String', 'bbqVersionMinor', rootProject.ext.versionMinor)
+        buildConfigField('String', 'bbqVersionPatch', rootProject.ext.versionPatch)
+    }
+}
 
 dependencies {
     compile "com.android.support:support-annotations:${rootProject.supportLibVersion}"

--- a/bbq/java/com/google/bbq/BroadcastQueryClient.java
+++ b/bbq/java/com/google/bbq/BroadcastQueryClient.java
@@ -27,6 +27,7 @@ import android.text.TextUtils;
 import android.util.Log;
 import com.google.bbq.Protobufs.BroadcastQuery;
 import com.google.bbq.Protobufs.BroadcastQueryResponse;
+import com.google.bbq.internal.ClientVersionUtil;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.MessageLite;
 import java.io.IOException;
@@ -186,6 +187,7 @@ public final class BroadcastQueryClient {
         queryIntent.setPackage(responderPackage);
         queryIntent.putExtra(QueryUtil.EXTRA_QUERY_MESSAGE,
                 BroadcastQuery.newBuilder()
+                        .setClientVersion(ClientVersionUtil.getClientVersion())
                         .setRequestingApp(mContext.getPackageName())
                         .setDataType(pendingQuery.mDataType)
                         .setRequestId(pendingQuery.mQueryId)

--- a/bbq/java/com/google/bbq/internal/ClientVersionUtil.java
+++ b/bbq/java/com/google/bbq/internal/ClientVersionUtil.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 The OpenYOLO Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.bbq.internal;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
+
+import com.google.bbq.BuildConfig;
+import com.google.bbq.Protobufs;
+
+/**
+ * Holds the client version that is built from the static configuration.
+ */
+public final class ClientVersionUtil {
+
+    private static final String VENDOR = "openid.net";
+
+    @NonNull
+    private static final Protobufs.ClientVersion BUILD_CLIENT_VERSION =
+            Protobufs.ClientVersion.newBuilder()
+                    .setVendor(VENDOR)
+                    .setMajor(parseVersionPart(BuildConfig.bbqVersionMajor))
+                    .setMinor(parseVersionPart(BuildConfig.bbqVersionMinor))
+                    .setPatch(parseVersionPart(BuildConfig.bbqVersionPatch))
+                    .build();
+
+    private static Protobufs.ClientVersion sClientVersion;
+
+    /**
+     * Retrieve the client version, typically sourced from the static build information.
+     */
+    @NonNull
+    public static Protobufs.ClientVersion getClientVersion() {
+        Protobufs.ClientVersion clientVersion = sClientVersion;
+        if (clientVersion == null) {
+            clientVersion = BUILD_CLIENT_VERSION;
+            sClientVersion = clientVersion;
+        }
+
+        return clientVersion;
+    }
+
+    /**
+     * Overrides the client version, for testing purposes.
+     */
+    @VisibleForTesting
+    public static void setClientVersion(Protobufs.ClientVersion clientVersion) {
+        sClientVersion = clientVersion;
+    }
+
+    @VisibleForTesting
+    static int parseVersionPart(String versionPart) {
+        if (versionPart == null || versionPart.isEmpty()) {
+            return 0;
+        }
+
+        int versionNum;
+        try {
+            versionNum = Integer.parseInt(versionPart);
+        } catch (NumberFormatException ex) {
+            return 0;
+        }
+
+        if (versionNum < 0) {
+            return 0;
+        }
+
+        return versionNum;
+    }
+
+}

--- a/bbq/java/com/google/bbq/internal/package-info.java
+++ b/bbq/java/com/google/bbq/internal/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 The OpenYOLO Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Data types and utility classes that are used internally by BBQ. _NOTE_: The contents of
+ * this package are _not_ part of the public API, and may change at any time.
+ */
+package com.google.bbq.internal;

--- a/bbq/proto/bbq.proto
+++ b/bbq/proto/bbq.proto
@@ -23,7 +23,7 @@ option java_outer_classname = "Protobufs";
 
 message BroadcastQuery {
     // required - The BBQ client version.
-    ClientVersion version = 1;
+    ClientVersion clientVersion = 1;
 
     // required - the type of data to be discovered
     string dataType = 2;
@@ -52,5 +52,15 @@ message BroadcastQueryResponse {
 }
 
 message ClientVersion {
-    string version = 1;
+    // required
+    string vendor = 1;
+
+    // required
+    uint32 major = 3;
+
+    // required
+    uint32 minor = 4;
+
+    // required
+    uint32 patch = 5;
 }

--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,18 @@ try {
     project.ext.versionNum = grgit.log(includes:['HEAD']).size()
     project.ext.versionDate = lastCommit.getDate()
     project.ext.versionName = grgit.describe()
+
+    def emptyValue = "\"\"";
     if (project.ext.versionName == null) {
         project.ext.versionName = "DEV"
+        project.ext.versionMajor = emptyValue
+        project.ext.versionMinor = emptyValue
+        project.ext.versionPatch = emptyValue
+    } else {
+        def parts = project.ext.versionName.split("[\\.-]")
+        project.ext.versionMajor = (parts.length > 0) ? parts[0] : emptyValue;
+        project.ext.versionMinor = (parts.length > 1) ? parts[1] : emptyValue;
+        project.ext.versionPatch = (parts.length > 2) ? parts[2] : emptyValue;
     }
 } catch (Exception ex) {
     logger.lifecycle(

--- a/protocol/build.gradle
+++ b/protocol/build.gradle
@@ -3,7 +3,16 @@ apply plugin: 'com.android.library'
 apply from:'../config/android-common.gradle'
 apply from:'../config/protobuf.gradle'
 
-android.defaultConfig.project.archivesBaseName = 'data'
+android {
+    defaultConfig {
+        project.archivesBaseName = 'protocol'
+        consumerProguardFiles 'proguard-rules.txt'
+
+        buildConfigField('String', 'clientVersionMajor', rootProject.ext.versionMajor)
+        buildConfigField('String', 'clientVersionMinor', rootProject.ext.versionMinor)
+        buildConfigField('String', 'clientVersionPatch', rootProject.ext.versionPatch)
+    }
+}
 
 dependencies {
     compile "com.android.support:support-annotations:${rootProject.supportLibVersion}"

--- a/protocol/java/org/openyolo/protocol/HintRequest.java
+++ b/protocol/java/org/openyolo/protocol/HintRequest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openyolo.protocol.internal.AuthenticationMethodConverters;
 import org.openyolo.protocol.internal.ByteStringConverters;
+import org.openyolo.protocol.internal.ClientVersionUtil;
 import org.openyolo.protocol.internal.CollectionConverter;
 import org.openyolo.protocol.internal.NoopValueConverter;
 
@@ -159,6 +160,7 @@ public class HintRequest implements Parcelable {
     @NonNull
     public Protobufs.HintRetrieveRequest toProtocolBuffer() {
         return Protobufs.HintRetrieveRequest.newBuilder()
+                .setClientVersion(ClientVersionUtil.getClientVersion())
                 .addAllAuthMethods(
                         CollectionConverter.toList(
                                 mAuthMethods,

--- a/protocol/java/org/openyolo/protocol/RetrieveRequest.java
+++ b/protocol/java/org/openyolo/protocol/RetrieveRequest.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import org.openyolo.protocol.internal.AuthenticationMethodConverters;
 import org.openyolo.protocol.internal.ByteStringConverters;
+import org.openyolo.protocol.internal.ClientVersionUtil;
 import org.openyolo.protocol.internal.CollectionConverter;
 import org.openyolo.protocol.internal.NoopValueConverter;
 
@@ -140,6 +141,7 @@ public class RetrieveRequest implements Parcelable {
      */
     public Protobufs.CredentialRetrieveRequest toProtocolBuffer() {
         return Protobufs.CredentialRetrieveRequest.newBuilder()
+                .setClientVersion(ClientVersionUtil.getClientVersion())
                 .addAllAuthMethods(
                         CollectionConverter.toList(
                                 mAuthMethods,

--- a/protocol/java/org/openyolo/protocol/internal/ClientVersionUtil.java
+++ b/protocol/java/org/openyolo/protocol/internal/ClientVersionUtil.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 The OpenYOLO Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openyolo.protocol.internal;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
+
+import org.openyolo.protocol.BuildConfig;
+import org.openyolo.protocol.Protobufs;
+
+/**
+ * Holds the client version that is built from the static configuration.
+ */
+public final class ClientVersionUtil {
+
+    private static final String VENDOR = "openid.net";
+
+    @NonNull
+    private static final Protobufs.ClientVersion BUILD_CLIENT_VERSION =
+            Protobufs.ClientVersion.newBuilder()
+                    .setVendor(VENDOR)
+                    .setMajor(parseVersionPart(BuildConfig.clientVersionMajor))
+                    .setMinor(parseVersionPart(BuildConfig.clientVersionMinor))
+                    .setPatch(parseVersionPart(BuildConfig.clientVersionPatch))
+                    .build();
+
+    private static Protobufs.ClientVersion sClientVersion;
+
+    /**
+     * Retrieve the client version, typically sourced from the static build information.
+     */
+    @NonNull
+    public static Protobufs.ClientVersion getClientVersion() {
+        Protobufs.ClientVersion clientVersion = sClientVersion;
+        if (clientVersion == null) {
+            clientVersion = BUILD_CLIENT_VERSION;
+            sClientVersion = clientVersion;
+        }
+
+        return clientVersion;
+    }
+
+    /**
+     * Overrides the client version, for testing purposes.
+     */
+    @VisibleForTesting
+    public static void setClientVersion(Protobufs.ClientVersion clientVersion) {
+        sClientVersion = clientVersion;
+    }
+
+    @VisibleForTesting
+    static int parseVersionPart(String versionPart) {
+        if (versionPart == null || versionPart.isEmpty()) {
+            return 0;
+        }
+
+        int versionNum;
+        try {
+            versionNum = Integer.parseInt(versionPart);
+        } catch (NumberFormatException ex) {
+            return 0;
+        }
+
+        if (versionNum < 0) {
+            return 0;
+        }
+
+        return versionNum;
+    }
+
+}

--- a/protocol/javatests/org/openyolo/protocol/HintRequestTest.java
+++ b/protocol/javatests/org/openyolo/protocol/HintRequestTest.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openyolo.protocol.internal.ClientVersionUtil;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.valid4j.errors.RequireViolation;
@@ -94,6 +95,33 @@ public class HintRequestTest {
         assertThat(request.getPasswordSpecification())
                 .isEqualTo(PasswordSpecification.DEFAULT);
         assertThat(request.getAdditionalProperties()).isEmpty();
+    }
+
+    @Test
+    public void testToProtocolBuffer_includesClientVersion() {
+        String vendor = "test";
+        int major = 1;
+        int minor = 2;
+        int patch = 3;
+        ClientVersionUtil.setClientVersion(
+                Protobufs.ClientVersion.newBuilder()
+                        .setVendor(vendor)
+                        .setMajor(major)
+                        .setMinor(minor)
+                        .setPatch(patch)
+                        .build());
+
+        try {
+            HintRequest request = HintRequest.forEmailAndPasswordAccount();
+            Protobufs.HintRetrieveRequest proto = request.toProtocolBuffer();
+            assertThat(proto.hasClientVersion());
+            assertThat(proto.getClientVersion().getVendor()).isEqualTo(vendor);
+            assertThat(proto.getClientVersion().getMajor()).isEqualTo(major);
+            assertThat(proto.getClientVersion().getMinor()).isEqualTo(minor);
+            assertThat(proto.getClientVersion().getPatch()).isEqualTo(patch);
+        } finally {
+            ClientVersionUtil.setClientVersion(null);
+        }
     }
 
     @Test

--- a/protocol/javatests/org/openyolo/protocol/RetrieveRequestTest.java
+++ b/protocol/javatests/org/openyolo/protocol/RetrieveRequestTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openyolo.protocol.internal.ClientVersionUtil;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -121,6 +122,34 @@ public class RetrieveRequestTest {
     @Test(expected = NullPointerException.class)
     public void testAdapter_nullArray() throws IOException {
         Protobufs.CredentialRetrieveRequest.parseFrom((byte[]) null);
+    }
+
+    @Test
+    public void testToProtocolBuffer_includesClientVersion() {
+        String vendor = "test";
+        int major = 1;
+        int minor = 2;
+        int patch = 3;
+        ClientVersionUtil.setClientVersion(
+                Protobufs.ClientVersion.newBuilder()
+                        .setVendor(vendor)
+                        .setMajor(major)
+                        .setMinor(minor)
+                        .setPatch(patch)
+                        .build());
+
+        try {
+            RetrieveRequest request = RetrieveRequest.forAuthenticationMethods(
+                    AuthenticationMethods.EMAIL);
+            Protobufs.CredentialRetrieveRequest proto = request.toProtocolBuffer();
+            assertThat(proto.hasClientVersion());
+            assertThat(proto.getClientVersion().getVendor()).isEqualTo(vendor);
+            assertThat(proto.getClientVersion().getMajor()).isEqualTo(major);
+            assertThat(proto.getClientVersion().getMinor()).isEqualTo(minor);
+            assertThat(proto.getClientVersion().getPatch()).isEqualTo(patch);
+        } finally {
+            ClientVersionUtil.setClientVersion(null);
+        }
     }
 
     private static <T, U> void assertMapsEqual(Map<T, U> a, Map<T, U> b) {

--- a/protocol/javatests/org/openyolo/protocol/internal/ClientVersionUtilTest.java
+++ b/protocol/javatests/org/openyolo/protocol/internal/ClientVersionUtilTest.java
@@ -1,0 +1,40 @@
+package org.openyolo.protocol.internal;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class ClientVersionUtilTest {
+
+    @Test
+    public void testParseVersionPart() {
+        assertThat(ClientVersionUtil.parseVersionPart("0")).isEqualTo(0);
+        assertThat(ClientVersionUtil.parseVersionPart("2")).isEqualTo(2);
+        assertThat(ClientVersionUtil.parseVersionPart("1024")).isEqualTo(1024);
+    }
+
+    @Test
+    public void testParseVersionPart_nullValue() {
+        assertThat(ClientVersionUtil.parseVersionPart(null)).isEqualTo(0);
+    }
+
+    @Test
+    public void testParseVersionPart_emptyValue() {
+        assertThat(ClientVersionUtil.parseVersionPart("")).isEqualTo(0);
+    }
+
+    @Test
+    public void testParseVersionPart_negativeValue() {
+        assertThat(ClientVersionUtil.parseVersionPart("-1")).isEqualTo(0);
+    }
+
+    @Test
+    public void testParseVersionPart_tooBigValue() {
+        assertThat(ClientVersionUtil.parseVersionPart("10000000000")).isEqualTo(0);
+    }
+}

--- a/protocol/proguard-rules.txt
+++ b/protocol/proguard-rules.txt
@@ -1,0 +1,8 @@
+# valid4j use reflection to inject Providers and Policy
+-keep class org.valid4j.** { *; }
+
+# it is safe to ignore okio warnings
+-dontwarn okio.**
+
+# Hamcrest reflection
+-keep class org.hamcrest.** { *; }

--- a/protocol/proto/openyolo.proto
+++ b/protocol/proto/openyolo.proto
@@ -22,8 +22,10 @@ option java_package = "org.openyolo.protocol";
 option java_outer_classname = "Protobufs";
 
 message CredentialRetrieveRequest {
+    ClientVersion clientVersion = 1;
+
     // at least one authMethod required
-    repeated AuthenticationMethod authMethods = 1;
+    repeated AuthenticationMethod authMethods = 2;
 
     map<string, TokenRequestInfo> supportedTokenProviders = 3;
     map<string, bytes> additionalProps = 4;
@@ -35,12 +37,14 @@ message CredentialRetrieveBbqResponse {
 }
 
 message HintRetrieveRequest {
-    // at least one authMethod required
-    repeated AuthenticationMethod authMethods = 1;
+    ClientVersion clientVersion = 1;
 
-    PasswordSpecification passwordSpec = 2;
-    map<string, TokenRequestInfo> supportedTokenProviders = 3;
-    map<string, bytes> additionalProps = 4;
+    // at least one authMethod required
+    repeated AuthenticationMethod authMethods = 2;
+
+    PasswordSpecification passwordSpec = 3;
+    map<string, TokenRequestInfo> supportedTokenProviders = 4;
+    map<string, bytes> additionalProps = 5;
 }
 
 message HintRetrieveResult {
@@ -104,4 +108,18 @@ message TokenRequestInfo {
     string clientId = 1;
     string nonce = 2;
     map<string, bytes> additionalProps = 3;
+}
+
+message ClientVersion {
+    // required
+    string vendor = 1;
+
+    // required
+    uint32 major = 2;
+
+    // required
+    uint32 minor = 3;
+
+    // required
+    uint32 patch = 4;
 }

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -5,6 +5,10 @@ android {
     defaultConfig {
         project.archivesBaseName = 'openyolo-spi'
         consumerProguardFiles 'proguard-rules.txt'
+
+        buildConfigField('String', 'spiVersionMajor', rootProject.ext.versionMajor)
+        buildConfigField('String', 'spiVersionMinor', rootProject.ext.versionMinor)
+        buildConfigField('String', 'spiVersionPatch', rootProject.ext.versionPatch)
     }
 }
 


### PR DESCRIPTION
The version is taken from new BuildConfig properties, that are in turn generated from the closest git tag to the current commit.

This is stacked upon #29.