### PR TITLE
Implementation of delete in Barbican

### DIFF
--- a/demoproviders/barbican/AndroidManifest.xml
+++ b/demoproviders/barbican/AndroidManifest.xml
@@ -120,9 +120,19 @@
             android:excludeFromRecents="true"
             android:exported="false" />
 
+        <activity android:name=".provider.DeleteCredentialActivity"
+            android:theme="@style/AppTheme.Dialog"
+            android:exported="true"
+            android:excludeFromRecents="true">
+            <intent-filter>
+                <action android:name="org.openyolo.credential.delete"/>
+                <category android:name="org.openyolo" />
+            </intent-filter>
+        </activity>
+
         <activity
             android:name=".NeverSaveListActivity"
-            android:theme="@style/AppTheme"/>
+            android:theme="@style/AppTheme"
             android:exported="false" />
 
         <service

--- a/demoproviders/barbican/build.gradle
+++ b/demoproviders/barbican/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     compile "com.android.support:design:${rootProject.supportLibVersion}"
     compile "com.android.support:recyclerview-v7:${rootProject.supportLibVersion}"
     compile 'com.madgag.spongycastle:core:1.54.0.0'
-    compile 'com.google.guava:guava:20.0'
+    compile 'com.google.guava:guava:22.0-rc1-android'
 
     compile 'com.jakewharton:butterknife:8.5.1'
     compile 'com.github.bumptech.glide:glide:3.7.0'
@@ -35,7 +35,7 @@ dependencies {
 
     apply from: "${rootDir}/config/testdeps.gradle", to:it
     testCompile "com.android.support:support-annotations:${rootProject.supportLibVersion}"
-    testCompile 'com.google.guava:guava:20.0'
+    testCompile 'com.google.guava:guava:22.0-rc1-android'
 }
 
 apply from: "${rootDir}/config/style.gradle"

--- a/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/provider/CallerUtil.java
+++ b/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/provider/CallerUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 The OpenYOLO Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openyolo.demoprovider.barbican.provider;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.openyolo.protocol.AuthenticationDomain;
+
+/**
+ * Extracts information on the caller of an activity.
+ */
+public final class CallerUtil {
+
+    /**
+     * Extracts the set of authentication domains for the caller of the provided activity.
+     */
+    @NonNull
+    public static Set<AuthenticationDomain> extractCallerAuthDomains(@NonNull Activity activity) {
+        ComponentName callingActivity = activity.getCallingActivity();
+        if (callingActivity == null) {
+            return Collections.emptySet();
+        }
+
+        String callingPackage = callingActivity.getPackageName();
+        return new HashSet<>(AuthenticationDomain.listForPackage(activity, callingPackage));
+    }
+
+    /**
+     * Determines the human-readable name of the caller of the provided activity.
+     */
+    public static String getCallingAppName(@NonNull Activity activity) {
+        try {
+            PackageManager pm = activity.getPackageManager();
+            ApplicationInfo info = pm.getApplicationInfo(activity.getCallingPackage(), 0);
+            return pm.getApplicationLabel(info).toString();
+        } catch (PackageManager.NameNotFoundException e) {
+            return "???";
+        }
+    }
+}

--- a/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/provider/DeleteCredentialActivity.java
+++ b/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/provider/DeleteCredentialActivity.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017 The OpenYOLO Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openyolo.demoprovider.barbican.provider;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.annotation.UiThread;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.WindowManager.LayoutParams;
+import android.widget.Button;
+import android.widget.TextView;
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import java.io.IOException;
+import java.util.Set;
+import org.openyolo.demoprovider.barbican.R;
+import org.openyolo.demoprovider.barbican.storage.CredentialStorageClient;
+import org.openyolo.demoprovider.barbican.storage.CredentialStorageClient.ConnectedCallback;
+import org.openyolo.protocol.AuthenticationDomain;
+import org.openyolo.protocol.Credential;
+import org.openyolo.protocol.CredentialDeleteRequest;
+import org.openyolo.protocol.CredentialDeleteResult;
+import org.openyolo.protocol.MalformedDataException;
+import org.openyolo.protocol.Protobufs;
+
+public class DeleteCredentialActivity extends AppCompatActivity implements ConnectedCallback {
+
+    private static final String LOG_TAG = "DeleteCrActivity";
+    private CredentialStorageClient mStorageClient;
+    private CredentialDeleteRequest mRequest;
+    private Set<AuthenticationDomain> mCallerAuthDomains;
+
+
+    @BindView(R.id.delete_prompt)
+    TextView mDeletePromptView;
+
+    @BindView(R.id.delete_yes_button)
+    Button mAcceptDeleteButton;
+
+    @BindView(R.id.delete_no_button)
+    Button mRefuseDeleteButton;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        try {
+            mRequest = CredentialDeleteRequest.fromRequestIntent(getIntent());
+        } catch (MalformedDataException ex) {
+            Log.w(LOG_TAG, "Failed to decode hint request from intent", ex);
+            setResultAndFinish(CredentialDeleteResult.BAD_REQUEST);
+            return;
+        }
+
+        mCallerAuthDomains = CallerUtil.extractCallerAuthDomains(this);
+
+        if (mCallerAuthDomains.isEmpty()) {
+            Log.w(LOG_TAG, "Unable to identify calling app");
+            setResultAndFinish(CredentialDeleteResult.BAD_REQUEST);
+            return;
+        }
+
+        // TODO: expand the caller auth domains to all equivalent domains
+
+        if (!mCallerAuthDomains.contains(mRequest.getCredential().getAuthenticationDomain())) {
+            setResultAndFinish(CredentialDeleteResult.BAD_REQUEST);
+            return;
+        }
+
+        CredentialStorageClient.connect(this, this);
+    }
+
+    @Override
+    public void onStorageConnected(CredentialStorageClient client) {
+        mStorageClient = client;
+
+        final Credential credentialToDelete = mRequest.getCredential();
+
+        if (!mStorageClient.isCreated()) {
+            Log.i(LOG_TAG, "Store is not yet initialized");
+            setResultAndFinish(CredentialDeleteResult.NO_MATCHING_CREDENTIAL);
+            return;
+        }
+
+        try {
+            Protobufs.Credential proto = credentialToDelete.toProtobuf();
+            if (!mStorageClient.hasCredential(proto)) {
+                setResultAndFinish(CredentialDeleteResult.NO_MATCHING_CREDENTIAL);
+                return;
+            }
+        } catch (IOException ex) {
+            setResultAndFinish(CredentialDeleteResult.UNKNOWN);
+        }
+
+        setContentView(R.layout.delete_layout);
+        ButterKnife.bind(this);
+
+        // monitor interactions outside of the dialog
+        getWindow().setFlags(
+                LayoutParams.FLAG_NOT_TOUCH_MODAL,
+                LayoutParams.FLAG_NOT_TOUCH_MODAL);
+        getWindow().setFlags(
+                        LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH,
+                        LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH);
+
+        String callingAppName = CallerUtil.getCallingAppName(this);
+        String savePromptTemplate = getString(R.string.delete_prompt_template);
+        mDeletePromptView.setText(String.format(
+                savePromptTemplate,
+                credentialToDelete.getIdentifier(),
+                callingAppName).trim());
+        mAcceptDeleteButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                try {
+                    mStorageClient.deleteCredential(credentialToDelete.toProtobuf());
+                    setResultAndFinish(CredentialDeleteResult.DELETED);
+                } catch (IOException e) {
+                    setResultAndFinish(CredentialDeleteResult.UNKNOWN);
+                }
+            }
+        });
+
+        mRefuseDeleteButton.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // TODO: record the fact that the user refused to delete this credential, so
+                // that subsequent requests can be auto-refused.
+                setResultAndFinish(CredentialDeleteResult.USER_REFUSED);
+            }
+        });
+    }
+
+    @Override
+    public void onBackPressed() {
+        setResultAndFinish(CredentialDeleteResult.USER_CANCELED);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (MotionEvent.ACTION_OUTSIDE == event.getAction()) {
+            setResultAndFinish(CredentialDeleteResult.USER_CANCELED);
+            return true;
+        }
+
+        return super.onTouchEvent(event);
+    }
+
+    @UiThread
+    private void setResultAndFinish(CredentialDeleteResult result) {
+        setResult(result.getResultCode(), result.toResultIntentData());
+        finish();
+    }
+}

--- a/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/provider/SaveCredentialActivity.java
+++ b/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/provider/SaveCredentialActivity.java
@@ -118,7 +118,6 @@ public class SaveCredentialActivity extends AppCompatActivity {
             return false;
         }
 
-
         return true;
     }
 

--- a/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/provider/SaveCredentialConfirmationActivity.java
+++ b/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/provider/SaveCredentialConfirmationActivity.java
@@ -16,8 +16,6 @@ package org.openyolo.demoprovider.barbican.provider;
 
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
@@ -82,13 +80,7 @@ public class SaveCredentialConfirmationActivity extends AppCompatActivity {
             finishWithResult(CredentialSaveResult.UNSPECIFIED);
         }
 
-        try {
-            PackageManager pm = getPackageManager();
-            ApplicationInfo info = pm.getApplicationInfo(getCallingPackage(), 0);
-            mCallingAppName = pm.getApplicationLabel(info).toString();
-        } catch (PackageManager.NameNotFoundException e) {
-            e.printStackTrace();
-        }
+        mCallingAppName = CallerUtil.getCallingAppName(this);
 
         CredentialStorageClient.connect(this, new CredentialStorageClient.ConnectedCallback() {
             @Override

--- a/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/storage/CredentialStorageApi.java
+++ b/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/storage/CredentialStorageApi.java
@@ -127,4 +127,11 @@ public interface CredentialStorageApi {
      * @throws IOException if the credential could not be deleted.
      */
     void deleteCredential(Credential credential) throws IOException;
+
+    /**
+     * Determines whether the store contains a credential with the same authentication domain,
+     * authentication method and identifier as the credential specified.
+     * @throws IOException if the credential store could not be read.
+     */
+    boolean hasCredential(Credential credential) throws IOException;
 }

--- a/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/storage/CredentialStorageClient.java
+++ b/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/storage/CredentialStorageClient.java
@@ -147,6 +147,11 @@ public class CredentialStorageClient implements CredentialStorageApi {
         return mApi.listCredentials(authDomains);
     }
 
+    @Override
+    public boolean hasCredential(Credential credential) throws IOException {
+        return mApi.hasCredential(credential);
+    }
+
     /**
      * Callback interface for notifing callers when the client is connected.
      */

--- a/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/storage/CredentialStorageService.java
+++ b/demoproviders/barbican/java/org/openyolo/demoprovider/barbican/storage/CredentialStorageService.java
@@ -146,6 +146,11 @@ public class CredentialStorageService extends Service implements CredentialStora
     }
 
     @Override
+    public boolean hasCredential(Credential credential) throws IOException {
+        return mStorage.hasCredential(credential);
+    }
+
+    @Override
     public List<Credential> listCredentials(List<AuthenticationDomain> authDomains)
             throws IOException {
         checkUnlocked();
@@ -171,7 +176,6 @@ public class CredentialStorageService extends Service implements CredentialStora
 
     @Override
     public void deleteCredential(Credential credential) throws IOException {
-        checkUnlocked();
         mStorage.deleteCredential(credential);
     }
 

--- a/demoproviders/barbican/res/layout/delete_layout.xml
+++ b/demoproviders/barbican/res/layout/delete_layout.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorPrimary"
+    android:orientation="vertical"
+    android:paddingTop="16dp"
+    android:paddingLeft="24dp"
+    android:paddingRight="24dp"
+    android:paddingBottom="8dp">
+
+  <ImageView
+      android:layout_width="48dp"
+      android:layout_height="48dp"
+      android:layout_gravity="center_horizontal"
+      android:contentDescription="@string/logo_contentDescription"
+      app:srcCompat="@drawable/app_icon"/>
+
+  <TextView
+      android:id="@+id/delete_prompt"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="20dp"
+      style="@style/TextAppearance.AppCompat.Subhead"/>
+
+  <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:gravity="end"
+      android:layout_marginTop="24dp"
+      android:orientation="horizontal">
+
+    <Button
+        android:id="@+id/delete_yes_button"
+        style="@style/Widget.AppCompat.Button.Borderless"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/delete_yes"/>
+
+    <Button
+        android:id="@+id/delete_no_button"
+        style="@style/Widget.AppCompat.Button.Colored"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="8dp"
+        android:layout_marginStart="8dp"
+        android:text="@string/delete_no"
+        android:textAppearance="@style/TextAppearance.AppCompat.Widget.Button"/>
+  </LinearLayout>
+
+</LinearLayout>

--- a/demoproviders/barbican/res/values/strings.xml
+++ b/demoproviders/barbican/res/values/strings.xml
@@ -30,9 +30,17 @@
         <xliff:g example="Netflix" id="appName">%1$s</xliff:g>
         to Barbican?
     </string>
+    <string name="delete_prompt_template">
+        Would you like to delete the account
+        <xliff:g example="alice@example.com" id="accountId">%1$s</xliff:g>
+        for
+        <xliff:g example="Netflix" id="appName">%2$s</xliff:g>?
+    </string>
     <string name="action_wipe_contentDescription">Wipe associations for save</string>
     <string name="remove_unpaired_api_dialog_title">Remove this App from the \"Never Save\" list?</string>
     <string name="openyolo_simple_yes">Yes</string>
     <string name="openyolo_simple_no">No</string>
     <string name="ask_delete_credential">Delete credential?</string>
+    <string name="delete_yes">Yes</string>
+    <string name="delete_no">No thanks</string>
 </resources>

--- a/protocol/java/org/openyolo/protocol/CredentialDeleteRequest.java
+++ b/protocol/java/org/openyolo/protocol/CredentialDeleteRequest.java
@@ -25,6 +25,7 @@ import android.support.annotation.Nullable;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.openyolo.protocol.internal.ByteStringConverters;
 import org.openyolo.protocol.internal.ClientVersionUtil;
@@ -140,7 +141,7 @@ public final class CredentialDeleteRequest {
         private Credential mCredential;
 
         @NonNull
-        private Map<String, ByteString> mAdditionalProps;
+        private Map<String, ByteString> mAdditionalProps = new HashMap<>();
 
         /**
          * Starts the process of describing a credential deletion request, based on the properties


### PR DESCRIPTION
This restructures the credential store in Barbican to hold each
credential in a separate file, with a name derived from the
authentication domain, authentication method and identifier. This
allows for credential deletion without knowing the crypto key.