### PR TITLE
Add additional property utility methods to Credential

### DIFF
--- a/protocol/java/org/openyolo/protocol/AdditionalPropertiesHelper.java
+++ b/protocol/java/org/openyolo/protocol/AdditionalPropertiesHelper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 The OpenYOLO Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openyolo.protocol;
+
+import android.support.annotation.Nullable;
+import java.nio.charset.Charset;
+
+/**
+ * Utility methods for reading and writing additional properties.
+ */
+public final class AdditionalPropertiesHelper {
+
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+    /**
+     * Encodes the provided string for use as an additional property, using UTF-8 encoding.
+     * If the provided string is `null`, then `null will be returned.
+     */
+    @Nullable
+    public static byte[] encodeStringValue(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+
+        return value.getBytes(UTF_8);
+    }
+
+    /**
+     * Decodes the provided byte array from an additional property value to a String. This
+     * assumes that the byte array was originally produced by {@link #encodeStringValue(String)}
+     * or equivalent code. If the provided byte array is `null`, then `null` will be returned.
+     */
+    @Nullable
+    public static String decodeStringValue(@Nullable byte[] value) {
+        if (value == null) {
+            return null;
+        }
+
+        return new String(value, UTF_8);
+    }
+}

--- a/protocol/java/org/openyolo/protocol/Credential.java
+++ b/protocol/java/org/openyolo/protocol/Credential.java
@@ -219,6 +219,31 @@ public final class Credential implements Parcelable {
             ByteStringConverters.BYTE_STRING_TO_BYTE_ARRAY);
     }
 
+    /**
+     * Returns the additional, non-standard property identified by the specified key. If this
+     * additional property does not exist, then `null` is returned.
+     */
+    @Nullable
+    public byte[] getAdditionalProperty(String key) {
+        ByteString value = mAdditionalProps.get(key);
+        if (value == null) {
+            return null;
+        }
+
+        return value.toByteArray();
+    }
+
+    /**
+     * Returns the additional, non-standard property identified by the specified key, where the
+     * value is assumed to be a UTF-8 encoded string. If this additional property does not exist,
+     * then `null` is returned.
+     */
+    @Nullable
+    public String getAdditionalPropertyAsString(String key) {
+        return AdditionalPropertiesHelper.decodeStringValue(
+                getAdditionalProperty(key));
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -403,11 +428,37 @@ public final class Credential implements Parcelable {
         /**
          * Specifies any additional, non-standard properties associated with the credential.
          */
+        @NonNull
         public Builder setAdditionalProperties(@Nullable Map<String, byte[]> additionalProps) {
             mAdditionalProps =
                 AdditionalPropertiesUtil.validateAdditionalProperties(additionalProps);
 
             return this;
+        }
+
+        /**
+         * Specifies an additional, non-standard property to include in the credential.
+         */
+        @NonNull
+        public Builder setAdditionalProperty(@NonNull String key, @Nullable byte[] value) {
+            ByteString immutableValue;
+            if (value == null) {
+                immutableValue = null;
+            } else {
+                immutableValue = ByteString.copyFrom(value);
+            }
+
+            mAdditionalProps.put(key, immutableValue);
+            return this;
+        }
+
+        /**
+         * Specifies an additional, non-standard property with a string value to include in the
+         * credential.
+         */
+        @NonNull
+        public Builder setAdditionalPropertyAsString(@NonNull String key, @Nullable String value) {
+            return setAdditionalProperty(key, AdditionalPropertiesHelper.encodeStringValue(value));
         }
 
         /**


### PR DESCRIPTION
Implementation of #99 for Credential, need to add equivalent methods to other types (where are mix-ins when you need them???).