### PR TITLE
Refactor additional properties utility methods

### DIFF
--- a/protocol/java/org/openyolo/protocol/AdditionalPropertiesBuilder.java
+++ b/protocol/java/org/openyolo/protocol/AdditionalPropertiesBuilder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 The OpenYOLO Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openyolo.protocol;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import java.util.Map;
+
+/**
+ * The contract that builders must adhere to if they build model types that include
+ * additional properties.
+ */
+public interface AdditionalPropertiesBuilder<
+        ModelT extends AdditionalPropertiesContainer,
+        BuilderT extends AdditionalPropertiesBuilder<ModelT, BuilderT>> {
+
+    /**
+     * Specifies any additional, non-standard properties associated with the credential.
+     */
+    @NonNull
+    BuilderT setAdditionalProperties(@Nullable Map<String, byte[]> additionalProps);
+
+    /**
+     * Specifies an additional, non-standard property to include in the credential.
+     */
+    @NonNull
+    BuilderT setAdditionalProperty(@NonNull String key, @Nullable byte[] value);
+
+    /**
+     * Specifies an additional, non-standard property with a string value to include in the
+     * credential.
+     */
+    @NonNull
+    BuilderT setAdditionalPropertyAsString(@NonNull String key, @Nullable String value);
+
+    /**
+     * Creates an instance of the model type.
+     */
+    @NonNull
+    ModelT build();
+}

--- a/protocol/java/org/openyolo/protocol/AdditionalPropertiesContainer.java
+++ b/protocol/java/org/openyolo/protocol/AdditionalPropertiesContainer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 The OpenYOLO Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openyolo.protocol;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import java.util.Map;
+
+/**
+ * Implemented by all model types that can hold additional, non-standard properties.
+ */
+public interface AdditionalPropertiesContainer {
+
+    /**
+     * The set of additional, non-standard properties.
+     */
+    @NonNull
+    Map<String, byte[]> getAdditionalProperties();
+
+    /**
+     * Returns the additional, non-standard property identified by the specified key. If this
+     * additional property does not exist, then `null` is returned.
+     */
+    @Nullable
+    byte[] getAdditionalProperty(String key);
+
+    /**
+     * Returns the additional, non-standard property identified by the specified key, where the
+     * value is assumed to be a UTF-8 encoded string. If this additional property does not exist,
+     * then `null` is returned.
+     */
+    @Nullable
+    String getAdditionalPropertyAsString(String key);
+}

--- a/protocol/java/org/openyolo/protocol/Credential.java
+++ b/protocol/java/org/openyolo/protocol/Credential.java
@@ -47,7 +47,7 @@ import org.openyolo.protocol.internal.CollectionConverter;
  * @see <a href="http://spec.openyolo.org/openyolo-android-spec.html#credentials">
  *     OpenYOLO Specification: Credential</a>
  */
-public final class Credential implements Parcelable {
+public final class Credential implements Parcelable, AdditionalPropertiesContainer {
 
     /**
      * Parcelable reader for {@link Credential} instances.
@@ -209,39 +209,22 @@ public final class Credential implements Parcelable {
         return mIdToken;
     }
 
-    /**
-     * Additional, non-standard properties associated with the credential.
-     */
+    @Override
     @NonNull
     public Map<String, byte[]> getAdditionalProperties() {
-        return CollectionConverter.convertMapValues(
-            mAdditionalProps,
-            ByteStringConverters.BYTE_STRING_TO_BYTE_ARRAY);
+        return AdditionalPropertiesUtil.convertValuesToByteArrays(mAdditionalProps);
     }
 
-    /**
-     * Returns the additional, non-standard property identified by the specified key. If this
-     * additional property does not exist, then `null` is returned.
-     */
+    @Override
     @Nullable
     public byte[] getAdditionalProperty(String key) {
-        ByteString value = mAdditionalProps.get(key);
-        if (value == null) {
-            return null;
-        }
-
-        return value.toByteArray();
+        return AdditionalPropertiesUtil.getPropertyValue(mAdditionalProps, key);
     }
 
-    /**
-     * Returns the additional, non-standard property identified by the specified key, where the
-     * value is assumed to be a UTF-8 encoded string. If this additional property does not exist,
-     * then `null` is returned.
-     */
+    @Override
     @Nullable
     public String getAdditionalPropertyAsString(String key) {
-        return AdditionalPropertiesHelper.decodeStringValue(
-                getAdditionalProperty(key));
+        return AdditionalPropertiesUtil.getPropertyValueAsString(mAdditionalProps, key);
     }
 
     @Override
@@ -259,7 +242,7 @@ public final class Credential implements Parcelable {
     /**
      * Creates instances of {@link Credential}.
      */
-    public static final class Builder {
+    public static final class Builder implements AdditionalPropertiesBuilder<Credential, Builder> {
 
         private String mId;
         private AuthenticationMethod mAuthMethod;
@@ -436,34 +419,24 @@ public final class Credential implements Parcelable {
             return this;
         }
 
-        /**
-         * Specifies an additional, non-standard property to include in the credential.
-         */
+        @Override
         @NonNull
         public Builder setAdditionalProperty(@NonNull String key, @Nullable byte[] value) {
-            ByteString immutableValue;
-            if (value == null) {
-                immutableValue = null;
-            } else {
-                immutableValue = ByteString.copyFrom(value);
-            }
-
-            mAdditionalProps.put(key, immutableValue);
+            AdditionalPropertiesUtil.setPropertyValue(mAdditionalProps, key, value);
             return this;
         }
 
-        /**
-         * Specifies an additional, non-standard property with a string value to include in the
-         * credential.
-         */
+        @Override
         @NonNull
         public Builder setAdditionalPropertyAsString(@NonNull String key, @Nullable String value) {
-            return setAdditionalProperty(key, AdditionalPropertiesHelper.encodeStringValue(value));
+            AdditionalPropertiesUtil.setPropertyValueAsString(mAdditionalProps, key, value);
+            return this;
         }
 
         /**
          * Creates the {@link Credential credential} instance with all properties specified.
          */
+        @Override
         @NonNull
         public Credential build() {
             return new Credential(this);

--- a/protocol/java/org/openyolo/protocol/CredentialDeleteRequest.java
+++ b/protocol/java/org/openyolo/protocol/CredentialDeleteRequest.java
@@ -27,9 +27,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.openyolo.protocol.internal.ByteStringConverters;
+import org.openyolo.protocol.internal.AdditionalPropertiesUtil;
 import org.openyolo.protocol.internal.ClientVersionUtil;
-import org.openyolo.protocol.internal.CollectionConverter;
 import org.openyolo.protocol.internal.IntentProtocolBufferExtractor;
 
 /**
@@ -38,7 +37,7 @@ import org.openyolo.protocol.internal.IntentProtocolBufferExtractor;
  * @see <a href="http://spec.openyolo.org/openyolo-android-spec.html#credential-deletion">
  *     OpenYOLO Specification: Credential Deletion</a>
  */
-public final class CredentialDeleteRequest {
+public final class CredentialDeleteRequest implements AdditionalPropertiesContainer {
 
     /**
      * Returns a deletion request for the given credential.
@@ -111,40 +110,22 @@ public final class CredentialDeleteRequest {
         return mCredential;
     }
 
-    /**
-     * The additional, non-standard properties specified by the client as part of this
-     * deletion request.
-     */
+    @Override
     @NonNull
     public Map<String, byte[]> getAdditionalProperties() {
-        return CollectionConverter.convertMapValues(
-                mAdditionalProps,
-                ByteStringConverters.BYTE_STRING_TO_BYTE_ARRAY);
+        return AdditionalPropertiesUtil.convertValuesToByteArrays(mAdditionalProps);
     }
 
-    /**
-     * Returns the additional, non-standard property identified by the specified key. If this
-     * additional property does not exist, then `null` is returned.
-     */
+    @Override
     @Nullable
     public byte[] getAdditionalProperty(String key) {
-        ByteString value = mAdditionalProps.get(key);
-        if (value == null) {
-            return null;
-        }
-
-        return value.toByteArray();
+        return AdditionalPropertiesUtil.getPropertyValue(mAdditionalProps, key);
     }
 
-    /**
-     * Returns the additional, non-standard property identified by the specified key, where the
-     * value is assumed to be a UTF-8 encoded string. If this additional property does not exist,
-     * then `null` is returned.
-     */
+    @Override
     @Nullable
     public String getAdditionalPropertyAsString(String key) {
-        return AdditionalPropertiesHelper.decodeStringValue(
-                getAdditionalProperty(key));
+        return AdditionalPropertiesUtil.getPropertyValueAsString(mAdditionalProps, key);
     }
 
     /**
@@ -161,7 +142,8 @@ public final class CredentialDeleteRequest {
     /**
      * Creates instances of {@link CredentialDeleteRequest}.
      */
-    public static final class Builder {
+    public static final class Builder
+            implements AdditionalPropertiesBuilder<CredentialDeleteRequest, Builder> {
 
         @NonNull
         private Credential mCredential;
@@ -200,39 +182,26 @@ public final class CredentialDeleteRequest {
             return this;
         }
 
-        /**
-         * Specifies the set of additional, non-standard properties to carry with the credential
-         * deletion request. A null map is treated as an empty map.
-         */
+        @Override
+        @NonNull
         public Builder setAdditionalProperties(
                 @Nullable Map<String, byte[]> additionalProperties) {
             mAdditionalProps = validateAdditionalProperties(additionalProperties);
             return this;
         }
 
-        /**
-         * Specifies an additional, non-standard property to include in the request.
-         */
+        @Override
         @NonNull
         public Builder setAdditionalProperty(@NonNull String key, @Nullable byte[] value) {
-            ByteString immutableValue;
-            if (value == null) {
-                immutableValue = null;
-            } else {
-                immutableValue = ByteString.copyFrom(value);
-            }
-
-            mAdditionalProps.put(key, immutableValue);
+            AdditionalPropertiesUtil.setPropertyValue(mAdditionalProps, key, value);
             return this;
         }
 
-        /**
-         * Specifies an additional, non-standard property with a string value to include in the
-         * request.
-         */
+        @Override
         @NonNull
         public Builder setAdditionalPropertyAsString(@NonNull String key, @Nullable String value) {
-            return setAdditionalProperty(key, AdditionalPropertiesHelper.encodeStringValue(value));
+            AdditionalPropertiesUtil.setPropertyValueAsString(mAdditionalProps, key, value);
+            return this;
         }
 
         private Builder setAdditionalPropertiesFromProto(
@@ -244,6 +213,8 @@ public final class CredentialDeleteRequest {
         /**
          * Creates the credential deletion request, from the specified properties.
          */
+        @Override
+        @NonNull
         public CredentialDeleteRequest build() {
             return new CredentialDeleteRequest(this);
         }

--- a/protocol/java/org/openyolo/protocol/CredentialDeleteResult.java
+++ b/protocol/java/org/openyolo/protocol/CredentialDeleteResult.java
@@ -26,8 +26,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.openyolo.protocol.internal.AdditionalPropertiesUtil;
-import org.openyolo.protocol.internal.ByteStringConverters;
-import org.openyolo.protocol.internal.CollectionConverter;
 import org.openyolo.protocol.internal.IntentProtocolBufferExtractor;
 
 /**
@@ -37,7 +35,7 @@ import org.openyolo.protocol.internal.IntentProtocolBufferExtractor;
  * @see <a href="http://spec.openyolo.org/openyolo-android-spec.html#credential-deletion">
  *     OpenYOLO Specification: Credential Deletion</a>
  */
-public final class CredentialDeleteResult {
+public final class CredentialDeleteResult implements AdditionalPropertiesContainer {
 
     /**
      * Indicates that the provider returned a response that could not be interpreted.
@@ -214,14 +212,10 @@ public final class CredentialDeleteResult {
         return mResultCode;
     }
 
-    /**
-     * The additional, non-standard properties returned by the credential provider as part of the
-     * credential deletion result, if available.
-     */
+    @Override
+    @NonNull
     public Map<String, byte[]> getAdditionalProperties() {
-        return CollectionConverter.convertMapValues(
-                mAdditionalProps,
-                ByteStringConverters.BYTE_STRING_TO_BYTE_ARRAY);
+        return AdditionalPropertiesUtil.convertValuesToByteArrays(mAdditionalProps);
     }
 
     /**
@@ -230,12 +224,7 @@ public final class CredentialDeleteResult {
      */
     @Nullable
     public byte[] getAdditionalProperty(String key) {
-        ByteString value = mAdditionalProps.get(key);
-        if (value == null) {
-            return null;
-        }
-
-        return value.toByteArray();
+        return AdditionalPropertiesUtil.getPropertyValue(mAdditionalProps, key);
     }
 
     /**
@@ -245,8 +234,7 @@ public final class CredentialDeleteResult {
      */
     @Nullable
     public String getAdditionalPropertyAsString(String key) {
-        return AdditionalPropertiesHelper.decodeStringValue(
-                getAdditionalProperty(key));
+        return AdditionalPropertiesUtil.getPropertyValueAsString(mAdditionalProps, key);
     }
 
     /**
@@ -273,7 +261,8 @@ public final class CredentialDeleteResult {
     /**
      * Creates instances of {@link CredentialDeleteResult}.
      */
-    public static final class Builder {
+    public static final class Builder
+            implements AdditionalPropertiesBuilder<CredentialDeleteResult, Builder> {
 
         private int mResultCode;
 
@@ -311,39 +300,26 @@ public final class CredentialDeleteResult {
             return this;
         }
 
-        /**
-         * Specifies the set of additional, non-standard properties to carry with the credential
-         * deletion result. A null map is treated as an empty map.
-         */
+        @Override
+        @NonNull
         public Builder setAdditionalProperties(@Nullable Map<String, byte[]> additionalProperties) {
             mAdditionalProps = AdditionalPropertiesUtil.validateAdditionalProperties(
                     additionalProperties);
             return this;
         }
 
-        /**
-         * Specifies an additional, non-standard property to include in the result.
-         */
+        @Override
         @NonNull
         public Builder setAdditionalProperty(@NonNull String key, @Nullable byte[] value) {
-            ByteString immutableValue;
-            if (value == null) {
-                immutableValue = null;
-            } else {
-                immutableValue = ByteString.copyFrom(value);
-            }
-
-            mAdditionalProps.put(key, immutableValue);
+            AdditionalPropertiesUtil.setPropertyValue(mAdditionalProps, key, value);
             return this;
         }
 
-        /**
-         * Specifies an additional, non-standard property with a string value to include in the
-         * result.
-         */
+        @Override
         @NonNull
         public Builder setAdditionalPropertyAsString(@NonNull String key, @Nullable String value) {
-            return setAdditionalProperty(key, AdditionalPropertiesHelper.encodeStringValue(value));
+            AdditionalPropertiesUtil.setPropertyValueAsString(mAdditionalProps, key, value);
+            return this;
         }
 
         private Builder setAdditionalPropertiesFromProto(
@@ -356,6 +332,8 @@ public final class CredentialDeleteResult {
         /**
          * Creates the credential deletion result, from the specified properties.
          */
+        @Override
+        @NonNull
         public CredentialDeleteResult build() {
             return new CredentialDeleteResult(this);
         }

--- a/protocol/java/org/openyolo/protocol/CredentialRetrieveRequest.java
+++ b/protocol/java/org/openyolo/protocol/CredentialRetrieveRequest.java
@@ -52,7 +52,7 @@ import org.openyolo.protocol.internal.TokenRequestInfoConverters;
  * @see <a href="http://spec.openyolo.org/openyolo-android-spec.html#credential-retrieval">
  *     OpenYOLO Specification: Credential Retrieval</a>
  */
-public class CredentialRetrieveRequest implements Parcelable {
+public class CredentialRetrieveRequest implements Parcelable, AdditionalPropertiesContainer {
 
     @VisibleForTesting
     static final Boolean DEFAULT_REQUIRE_USER_MEDIATION_VALUE = false;
@@ -178,39 +178,22 @@ public class CredentialRetrieveRequest implements Parcelable {
     }
 
 
-    /**
-     * Retrieves the raw, byte-array value of the named additional parameter.
-     */
+    @Override
     @NonNull
     public Map<String, byte[]> getAdditionalProperties() {
-        return CollectionConverter.convertMapValues(
-                mAdditionalProps,
-                ByteStringConverters.BYTE_STRING_TO_BYTE_ARRAY);
+        return AdditionalPropertiesUtil.convertValuesToByteArrays(mAdditionalProps);
     }
 
-    /**
-     * Returns the additional, non-standard property identified by the specified key. If this
-     * additional property does not exist, then `null` is returned.
-     */
+    @Override
     @Nullable
     public byte[] getAdditionalProperty(String key) {
-        ByteString value = mAdditionalProps.get(key);
-        if (value == null) {
-            return null;
-        }
-
-        return value.toByteArray();
+        return AdditionalPropertiesUtil.getPropertyValue(mAdditionalProps, key);
     }
 
-    /**
-     * Returns the additional, non-standard property identified by the specified key, where the
-     * value is assumed to be a UTF-8 encoded string. If this additional property does not exist,
-     * then `null` is returned.
-     */
+    @Override
     @Nullable
     public String getAdditionalPropertyAsString(String key) {
-        return AdditionalPropertiesHelper.decodeStringValue(
-                getAdditionalProperty(key));
+        return AdditionalPropertiesUtil.getPropertyValueAsString(mAdditionalProps, key);
     }
 
     @Override
@@ -247,7 +230,8 @@ public class CredentialRetrieveRequest implements Parcelable {
     /**
      * Creates {@link CredentialRetrieveRequest} instances.
      */
-    public static final class Builder {
+    public static final class Builder
+            implements AdditionalPropertiesBuilder<CredentialRetrieveRequest, Builder> {
 
         private Set<AuthenticationMethod> mAuthMethods = new HashSet<>();
         private Map<String, TokenRequestInfo> mTokenProviders = new HashMap<>();
@@ -381,45 +365,32 @@ public class CredentialRetrieveRequest implements Parcelable {
             return this;
         }
 
-        /**
-         * Specifies additional, non-standard retrieve request parameters. The provided map must be
-         * non-null, and contain only non-null keys and values.
-         */
-        public Builder setAdditionalProperties(
-                @NonNull Map<String, byte[]> additionalProps) {
+        @Override
+        @NonNull
+        public Builder setAdditionalProperties(@Nullable Map<String, byte[]> additionalProps) {
             mAdditionalProps =
                     AdditionalPropertiesUtil.validateAdditionalProperties(additionalProps);
             return this;
         }
 
-        /**
-         * Specifies an additional, non-standard property to include in the credential.
-         */
+        @Override
         @NonNull
         public Builder setAdditionalProperty(@NonNull String key, @Nullable byte[] value) {
-            ByteString immutableValue;
-            if (value == null) {
-                immutableValue = null;
-            } else {
-                immutableValue = ByteString.copyFrom(value);
-            }
-
-            mAdditionalProps.put(key, immutableValue);
+            AdditionalPropertiesUtil.setPropertyValue(mAdditionalProps, key, value);
             return this;
         }
 
-        /**
-         * Specifies an additional, non-standard property with a string value to include in the
-         * credential.
-         */
+        @Override
         @NonNull
         public Builder setAdditionalPropertyAsString(@NonNull String key, @Nullable String value) {
-            return setAdditionalProperty(key, AdditionalPropertiesHelper.encodeStringValue(value));
+            AdditionalPropertiesUtil.setPropertyValueAsString(mAdditionalProps, key, value);
+            return this;
         }
 
         /**
          * Creates a {@link CredentialRetrieveRequest} using the properties set on the builder.
          */
+        @Override
         @NonNull
         public CredentialRetrieveRequest build() {
             return new CredentialRetrieveRequest(this);

--- a/protocol/java/org/openyolo/protocol/CredentialRetrieveResult.java
+++ b/protocol/java/org/openyolo/protocol/CredentialRetrieveResult.java
@@ -27,8 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openyolo.protocol.Protobufs.CredentialRetrieveResult.ResultCode;
 import org.openyolo.protocol.internal.AdditionalPropertiesUtil;
-import org.openyolo.protocol.internal.ByteStringConverters;
-import org.openyolo.protocol.internal.CollectionConverter;
 
 /**
  * Result data which is sent in response to a credential retrieve request. Contains a result code,
@@ -38,7 +36,7 @@ import org.openyolo.protocol.internal.CollectionConverter;
  * @see <a href="http://spec.openyolo.org/openyolo-android-spec.html#credential-retrieval">
  *     OpenYOLO Specification: Credential Retrieval</a>
  */
-public final class CredentialRetrieveResult {
+public final class CredentialRetrieveResult implements AdditionalPropertiesContainer {
 
     /**
      * Indicates that the provider returned a response that could not be interpreted.
@@ -187,39 +185,22 @@ public final class CredentialRetrieveResult {
         return mCredential;
     }
 
-    /**
-     * The additional, non-standard properties returned by the credential provider, if available.
-     */
+    @Override
     @NonNull
     public Map<String, byte[]> getAdditionalProperties() {
-        return CollectionConverter.convertMapValues(
-                mAdditionalProps,
-                ByteStringConverters.BYTE_STRING_TO_BYTE_ARRAY);
+        return AdditionalPropertiesUtil.convertValuesToByteArrays(mAdditionalProps);
     }
 
-    /**
-     * Returns the additional, non-standard property identified by the specified key. If this
-     * additional property does not exist, then `null` is returned.
-     */
+    @Override
     @Nullable
     public byte[] getAdditionalProperty(String key) {
-        ByteString value = mAdditionalProps.get(key);
-        if (value == null) {
-            return null;
-        }
-
-        return value.toByteArray();
+        return AdditionalPropertiesUtil.getPropertyValue(mAdditionalProps, key);
     }
 
-    /**
-     * Returns the additional, non-standard property identified by the specified key, where the
-     * value is assumed to be a UTF-8 encoded string. If this additional property does not exist,
-     * then `null` is returned.
-     */
+    @Override
     @Nullable
     public String getAdditionalPropertyAsString(String key) {
-        return AdditionalPropertiesHelper.decodeStringValue(
-                getAdditionalProperty(key));
+        return AdditionalPropertiesUtil.getPropertyValueAsString(mAdditionalProps, key);
     }
 
     /**
@@ -254,7 +235,8 @@ public final class CredentialRetrieveResult {
     /**
      * Creates validated {@link CredentialRetrieveResult} instances.
      */
-    public static final class Builder {
+    public static final class Builder
+            implements AdditionalPropertiesBuilder<CredentialRetrieveResult, Builder> {
 
         private int mResultCode;
         private Credential mCredential;
@@ -316,11 +298,8 @@ public final class CredentialRetrieveResult {
             return this;
         }
 
-        /**
-         * Specifies the set of additional, non-standard properties to return as part of this
-         * result. The keys and values of the provided map must not be null. The keys must not
-         * be empty.
-         */
+        @Override
+        @NonNull
         public Builder setAdditionalProperties(Map<String, byte[]> additionalProperties) {
             mAdditionalProps =
                     AdditionalPropertiesUtil.validateAdditionalProperties(additionalProperties);
@@ -335,34 +314,25 @@ public final class CredentialRetrieveResult {
             return this;
         }
 
-        /**
-         * Specifies an additional, non-standard property to include in the result.
-         */
+        @Override
         @NonNull
         public Builder setAdditionalProperty(@NonNull String key, @Nullable byte[] value) {
-            ByteString immutableValue;
-            if (value == null) {
-                immutableValue = null;
-            } else {
-                immutableValue = ByteString.copyFrom(value);
-            }
-
-            mAdditionalProps.put(key, immutableValue);
+            AdditionalPropertiesUtil.setPropertyValue(mAdditionalProps, key, value);
             return this;
         }
 
-        /**
-         * Specifies an additional, non-standard property with a string value to include in the
-         * result.
-         */
+        @Override
         @NonNull
         public Builder setAdditionalPropertyAsString(@NonNull String key, @Nullable String value) {
-            return setAdditionalProperty(key, AdditionalPropertiesHelper.encodeStringValue(value));
+            AdditionalPropertiesUtil.setPropertyValueAsString(mAdditionalProps, key, value);
+            return this;
         }
 
         /**
          * Finalizes the creation of the credential retrieval result.
          */
+        @Override
+        @NonNull
         public CredentialRetrieveResult build() {
             return new CredentialRetrieveResult(this);
         }

--- a/protocol/java/org/openyolo/protocol/CredentialSaveRequest.java
+++ b/protocol/java/org/openyolo/protocol/CredentialSaveRequest.java
@@ -39,7 +39,7 @@ import org.openyolo.protocol.internal.CollectionConverter;
  * @see <a href="https://spec.openyolo.org/openyolo-android-spec.html#saving-credentials">
  *     OpenYOLO specification: Saving Credentials</a>
  */
-public final class CredentialSaveRequest implements Parcelable {
+public final class CredentialSaveRequest implements Parcelable, AdditionalPropertiesContainer {
 
     /**
      * Parcelable reader for {@link CredentialSaveRequest} instances.
@@ -105,14 +105,22 @@ public final class CredentialSaveRequest implements Parcelable {
         return mCredential;
     }
 
-    /**
-     * The map of additional, non-standard properties included with this request.
-     */
+    @Override
     @NonNull
     public Map<String, byte[]> getAdditionalProperties() {
-        return CollectionConverter.convertMapValues(
-            mAdditionalProperties,
-            ByteStringConverters.BYTE_STRING_TO_BYTE_ARRAY);
+        return AdditionalPropertiesUtil.convertValuesToByteArrays(mAdditionalProperties);
+    }
+
+    @Nullable
+    @Override
+    public byte[] getAdditionalProperty(String key) {
+        return AdditionalPropertiesUtil.getPropertyValue(mAdditionalProperties, key);
+    }
+
+    @Nullable
+    @Override
+    public String getAdditionalPropertyAsString(String key) {
+        return AdditionalPropertiesUtil.getPropertyValueAsString(mAdditionalProperties, key);
     }
 
     @Override
@@ -141,7 +149,8 @@ public final class CredentialSaveRequest implements Parcelable {
     /**
      * Creates {@link CredentialSaveRequest} instances.
      */
-    public static final class Builder {
+    public static final class Builder
+            implements AdditionalPropertiesBuilder<CredentialSaveRequest, Builder> {
 
         private Credential mCredential;
         private Map<String, ByteString> mAdditionalProps = new HashMap<>();
@@ -187,10 +196,7 @@ public final class CredentialSaveRequest implements Parcelable {
             return this;
         }
 
-        /**
-         * Specifies the set of additional, non-standard properties to carry with the credential
-         * save request. A null map is treated as an empty map.
-         */
+        @Override
         @NonNull
         public Builder setAdditionalProperties(@Nullable Map<String, byte[]> additionalParams) {
             mAdditionalProps =
@@ -198,9 +204,24 @@ public final class CredentialSaveRequest implements Parcelable {
             return this;
         }
 
+        @NonNull
+        @Override
+        public Builder setAdditionalProperty(@NonNull String key, @Nullable byte[] value) {
+            AdditionalPropertiesUtil.setPropertyValue(mAdditionalProps, key, value);
+            return this;
+        }
+
+        @NonNull
+        @Override
+        public Builder setAdditionalPropertyAsString(@NonNull String key, @Nullable String value) {
+            AdditionalPropertiesUtil.setPropertyValueAsString(mAdditionalProps, key, value);
+            return this;
+        }
+
         /**
          * Finalizes the creation of the credential save request.
          */
+        @Override
         public CredentialSaveRequest build() {
             return new CredentialSaveRequest(this);
         }

--- a/protocol/java/org/openyolo/protocol/CredentialSaveResult.java
+++ b/protocol/java/org/openyolo/protocol/CredentialSaveResult.java
@@ -36,7 +36,7 @@ import org.openyolo.protocol.internal.CollectionConverter;
  * @see <a href="https://spec.openyolo.org/openyolo-android-spec.html#saving-credentials">
  *     OpenYOLO specification: Saving Credential</a>
  */
-public final class CredentialSaveResult {
+public final class CredentialSaveResult implements AdditionalPropertiesContainer {
 
     /**
      * Indicates that the provider returned a response that could not be interpreted.
@@ -212,20 +212,29 @@ public final class CredentialSaveResult {
         return mResultCode;
     }
 
-    /**
-     * The additional, non-standard properties returned by the credential provider, if available.
-     */
+    @Override
     @NonNull
     public Map<String, byte[]> getAdditionalProperties() {
-        return CollectionConverter.convertMapValues(
-                mAdditionalProperties,
-                ByteStringConverters.BYTE_STRING_TO_BYTE_ARRAY);
+        return AdditionalPropertiesUtil.convertValuesToByteArrays(mAdditionalProperties);
+    }
+
+    @Nullable
+    @Override
+    public byte[] getAdditionalProperty(String key) {
+        return AdditionalPropertiesUtil.getPropertyValue(mAdditionalProperties, key);
+    }
+
+    @Nullable
+    @Override
+    public String getAdditionalPropertyAsString(String key) {
+        return AdditionalPropertiesUtil.getPropertyValueAsString(mAdditionalProperties, key);
     }
 
     /**
      * Creates {@link CredentialSaveResult} instances.
      */
-    public static final class Builder {
+    public static final class Builder
+            implements AdditionalPropertiesBuilder<CredentialSaveResult, Builder> {
         private int mResultCode = CODE_UNKNOWN;
         private Map<String, ByteString> mAdditionalProps = new HashMap<>();
 
@@ -265,20 +274,33 @@ public final class CredentialSaveResult {
             return this;
         }
 
-        /**
-         * Specifies the set of additional, non-standard properties to carry with the credential
-         * deletion request. A null map is treated as an empty map.
-         */
+        @Override
+        @NonNull
         public Builder setAdditionalProperties(@Nullable Map<String, byte[]> additionalProps) {
             mAdditionalProps =
                     AdditionalPropertiesUtil.validateAdditionalProperties(additionalProps);
+            return this;
+        }
 
+        @Override
+        @NonNull
+        public Builder setAdditionalProperty(@NonNull String key, @Nullable byte[] value) {
+            AdditionalPropertiesUtil.setPropertyValue(mAdditionalProps, key, value);
+            return this;
+        }
+
+        @Override
+        @NonNull
+        public Builder setAdditionalPropertyAsString(@NonNull String key, @Nullable String value) {
+            AdditionalPropertiesUtil.setPropertyValueAsString(mAdditionalProps, key, value);
             return this;
         }
 
         /**
          * Finalizes the creation of the credential save result.
          */
+        @Override
+        @NonNull
         public CredentialSaveResult build() {
             return new CredentialSaveResult(this);
         }

--- a/protocol/java/org/openyolo/protocol/Hint.java
+++ b/protocol/java/org/openyolo/protocol/Hint.java
@@ -34,8 +34,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.openyolo.protocol.internal.AdditionalPropertiesUtil;
-import org.openyolo.protocol.internal.ByteStringConverters;
-import org.openyolo.protocol.internal.CollectionConverter;
 
 /**
  * A representation of a hint for use in account discovery or account creation. This provides a
@@ -49,7 +47,7 @@ import org.openyolo.protocol.internal.CollectionConverter;
  * @see <a href="http://spec.openyolo.org/openyolo-android-spec.html#hints">
  *     OpenYOLO specification: Hint</a>
  */
-public final class Hint implements Parcelable {
+public final class Hint implements Parcelable, AdditionalPropertiesContainer {
 
     /**
      * Parcelable reader for {@link Hint} instances.
@@ -203,14 +201,22 @@ public final class Hint implements Parcelable {
         return mIdToken;
     }
 
-    /**
-     * Additional, non-standard properties associated with the hint.
-     */
+    @Override
     @NonNull
     public Map<String, byte[]> getAdditionalProperties() {
-        return CollectionConverter.convertMapValues(
-                mAdditionalProps,
-                ByteStringConverters.BYTE_STRING_TO_BYTE_ARRAY);
+        return AdditionalPropertiesUtil.convertValuesToByteArrays(mAdditionalProps);
+    }
+
+    @Nullable
+    @Override
+    public byte[] getAdditionalProperty(String key) {
+        return AdditionalPropertiesUtil.getPropertyValue(mAdditionalProps, key);
+    }
+
+    @Nullable
+    @Override
+    public String getAdditionalPropertyAsString(String key) {
+        return AdditionalPropertiesUtil.getPropertyValueAsString(mAdditionalProps, key);
     }
 
     @Override
@@ -228,7 +234,7 @@ public final class Hint implements Parcelable {
     /**
      * Creates instances of {@link Hint}.
      */
-    public static final class Builder {
+    public static final class Builder implements AdditionalPropertiesBuilder<Hint, Builder> {
 
         @NonNull
         private String mId;
@@ -379,12 +385,25 @@ public final class Hint implements Parcelable {
             return this;
         }
 
-        /**
-         * Specifies any additional, non-standard properties associated with the hint.
-         */
+        @Override
+        @NonNull
         public Builder setAdditionalProperties(@Nullable Map<String, byte[]> additionalProps) {
             mAdditionalProps =
                     AdditionalPropertiesUtil.validateAdditionalProperties(additionalProps);
+            return this;
+        }
+
+        @Override
+        @NonNull
+        public Builder setAdditionalProperty(@NonNull String key, @Nullable byte[] value) {
+            AdditionalPropertiesUtil.setPropertyValue(mAdditionalProps, key, value);
+            return this;
+        }
+
+        @Override
+        @NonNull
+        public Builder setAdditionalPropertyAsString(@NonNull String key, @Nullable String value) {
+            AdditionalPropertiesUtil.setPropertyValueAsString(mAdditionalProps, key, value);
             return this;
         }
 
@@ -398,6 +417,8 @@ public final class Hint implements Parcelable {
         /**
          * Creates the {@link Hint hint} instance with the specified properties.
          */
+        @Override
+        @NonNull
         public Hint build() {
             return new Hint(this);
         }

--- a/protocol/java/org/openyolo/protocol/HintRetrieveRequest.java
+++ b/protocol/java/org/openyolo/protocol/HintRetrieveRequest.java
@@ -50,7 +50,7 @@ import org.openyolo.protocol.internal.TokenRequestInfoConverters;
  * @see <a href="http://spec.openyolo.org/openyolo-android-spec.html#hints">
  *     OpenYOLO specification: Hint</a>
  */
-public class HintRetrieveRequest implements Parcelable {
+public class HintRetrieveRequest implements Parcelable, AdditionalPropertiesContainer {
 
     /**
      * Parcelable reader for {@link HintRetrieveRequest} instances.
@@ -153,14 +153,22 @@ public class HintRetrieveRequest implements Parcelable {
         return mPasswordSpec;
     }
 
-    /**
-     * The map of additional, non-standard properties included with this request.
-     */
+    @Override
     @NonNull
     public Map<String, byte[]> getAdditionalProperties() {
-        return CollectionConverter.convertMapValues(
-                mAdditionalProperties,
-                ByteStringConverters.BYTE_STRING_TO_BYTE_ARRAY);
+        return AdditionalPropertiesUtil.convertValuesToByteArrays(mAdditionalProperties);
+    }
+
+    @Nullable
+    @Override
+    public byte[] getAdditionalProperty(String key) {
+        return AdditionalPropertiesUtil.getPropertyValue(mAdditionalProperties, key);
+    }
+
+    @Nullable
+    @Override
+    public String getAdditionalPropertyAsString(String key) {
+        return AdditionalPropertiesUtil.getPropertyValueAsString(mAdditionalProperties, key);
     }
 
     @Override
@@ -198,7 +206,8 @@ public class HintRetrieveRequest implements Parcelable {
     /**
      * Creates {@link HintRetrieveRequest} instances.
      */
-    public static final class Builder {
+    public static final class Builder
+            implements AdditionalPropertiesBuilder<HintRetrieveRequest, Builder> {
 
         private Set<AuthenticationMethod> mAuthMethods = new HashSet<>();
         private Map<String, ByteString> mAdditionalProps = new HashMap<>();
@@ -340,14 +349,25 @@ public class HintRetrieveRequest implements Parcelable {
             return this;
         }
 
-        /**
-         * Specifies additional, non-standard hint request parameters. The provided map
-         * must be non-null, and contain only non-empty keys and non-null values.
-         */
+        @Override
         @NonNull
-        public Builder setAdditionalProperties(@Nullable Map<String, byte[]> additionalParams) {
+        public Builder setAdditionalProperties(@Nullable Map<String, byte[]> additionalProps) {
             mAdditionalProps =
-                    AdditionalPropertiesUtil.validateAdditionalProperties(additionalParams);
+                    AdditionalPropertiesUtil.validateAdditionalProperties(additionalProps);
+            return this;
+        }
+
+        @Override
+        @NonNull
+        public Builder setAdditionalProperty(@NonNull String key, @Nullable byte[] value) {
+            AdditionalPropertiesUtil.setPropertyValue(mAdditionalProps, key, value);
+            return this;
+        }
+
+        @Override
+        @NonNull
+        public Builder setAdditionalPropertyAsString(@NonNull String key, @Nullable String value) {
+            AdditionalPropertiesUtil.setPropertyValueAsString(mAdditionalProps, key, value);
             return this;
         }
 
@@ -366,6 +386,7 @@ public class HintRetrieveRequest implements Parcelable {
         /**
          * Creates a {@link HintRetrieveRequest} with the properties specified on the builder.
          */
+        @Override
         @NonNull
         public HintRetrieveRequest build() {
             return new HintRetrieveRequest(this);

--- a/protocol/java/org/openyolo/protocol/HintRetrieveResult.java
+++ b/protocol/java/org/openyolo/protocol/HintRetrieveResult.java
@@ -27,8 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.openyolo.protocol.Protobufs.HintRetrieveResult.ResultCode;
 import org.openyolo.protocol.internal.AdditionalPropertiesUtil;
-import org.openyolo.protocol.internal.ByteStringConverters;
-import org.openyolo.protocol.internal.CollectionConverter;
 
 /**
  * A response to a {@link HintRetrieveRequest hint request}. The status code indicates the outcome
@@ -37,7 +35,7 @@ import org.openyolo.protocol.internal.CollectionConverter;
  * @see <a href="http://spec.openyolo.org/openyolo-android-spec.html#hints">
  *     OpenYOLO specification: Hint</a>
  */
-public final class HintRetrieveResult {
+public final class HintRetrieveResult implements AdditionalPropertiesContainer {
 
     /**
      * Indicates that the provider returned a response that could not be interpreted.
@@ -209,21 +207,29 @@ public final class HintRetrieveResult {
         return mHint;
     }
 
-    /**
-     * The additional, non-standard properties returned by the credential provider as part of the
-     * hint result, if available.
-     */
+    @Override
     @NonNull
     public Map<String, byte[]> getAdditionalProperties() {
-        return CollectionConverter.convertMapValues(
-                mAdditionalProps,
-                ByteStringConverters.BYTE_STRING_TO_BYTE_ARRAY);
+        return AdditionalPropertiesUtil.convertValuesToByteArrays(mAdditionalProps);
+    }
+
+    @Nullable
+    @Override
+    public byte[] getAdditionalProperty(String key) {
+        return AdditionalPropertiesUtil.getPropertyValue(mAdditionalProps, key);
+    }
+
+    @Nullable
+    @Override
+    public String getAdditionalPropertyAsString(String key) {
+        return AdditionalPropertiesUtil.getPropertyValueAsString(mAdditionalProps, key);
     }
 
     /**
      * Creates {@link HintRetrieveResult} instances.
      */
-    public static final class Builder {
+    public static final class Builder
+            implements AdditionalPropertiesBuilder<HintRetrieveResult, Builder> {
 
         private int mResultCode;
 
@@ -284,14 +290,25 @@ public final class HintRetrieveResult {
             return this;
         }
 
-        /**
-         * Specifies the set of additional, non-standard properties to return as part of this
-         * result. A null map is treated as an empty map. For a non-null map, all keys and values
-         * must not be null, and the keys must not be empty.
-         */
-        public Builder setAdditionalProperties(Map<String, byte[]> additionalProps) {
+        @Override
+        @NonNull
+        public Builder setAdditionalProperties(@Nullable Map<String, byte[]> additionalProps) {
             mAdditionalProps =
                     AdditionalPropertiesUtil.validateAdditionalProperties(additionalProps);
+            return this;
+        }
+
+        @Override
+        @NonNull
+        public Builder setAdditionalProperty(@NonNull String key, @Nullable byte[] value) {
+            AdditionalPropertiesUtil.setPropertyValue(mAdditionalProps, key, value);
+            return this;
+        }
+
+        @Override
+        @NonNull
+        public Builder setAdditionalPropertyAsString(@NonNull String key, @Nullable String value) {
+            AdditionalPropertiesUtil.setPropertyValueAsString(mAdditionalProps, key, value);
             return this;
         }
 
@@ -304,6 +321,8 @@ public final class HintRetrieveResult {
         /**
          * Creates the hint retrieve result, from the specified properties.
          */
+        @Override
+        @NonNull
         public HintRetrieveResult build() {
             return new HintRetrieveResult(this);
         }

--- a/protocol/java/org/openyolo/protocol/internal/AdditionalPropertiesUtil.java
+++ b/protocol/java/org/openyolo/protocol/internal/AdditionalPropertiesUtil.java
@@ -19,10 +19,12 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.openyolo.protocol.internal.CustomMatchers.notNullOrEmptyString;
 import static org.valid4j.Validation.validate;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.google.protobuf.ByteString;
 import java.util.HashMap;
 import java.util.Map;
+import org.openyolo.protocol.AdditionalPropertiesHelper;
 
 /**
  * Utility methods for the conversion and manipulation of additional property maps.
@@ -73,6 +75,73 @@ public final class AdditionalPropertiesUtil {
                 IllegalArgumentException.class);
 
         return additionalProps;
+    }
+
+    /**
+     * Extracts an additional property byte value from a map with immutable ByteString values.
+     */
+    @Nullable
+    public static byte[] getPropertyValue(
+            Map<String, ByteString> additionalProperties,
+            String key) {
+        ByteString value = additionalProperties.get(key);
+        if (value == null) {
+            return null;
+        }
+
+        return value.toByteArray();
+    }
+
+    /**
+     * Extracts an additional property string value from a map with immutable ByteString values.
+     */
+    @Nullable
+    public static String getPropertyValueAsString(
+            Map<String, ByteString> additionalProperties,
+            String key) {
+        return AdditionalPropertiesHelper.decodeStringValue(
+                getPropertyValue(additionalProperties, key));
+    }
+
+    /**
+     * Adds or replaces a property in the specified additional properties map that uses
+     * immutable ByteString values.
+     */
+    public static void setPropertyValue(
+            @NonNull Map<String, ByteString> additionalProperties,
+            @NonNull String key,
+            @Nullable byte[] value) {
+        ByteString immutableValue;
+        if (value == null) {
+            immutableValue = null;
+        } else {
+            immutableValue = ByteString.copyFrom(value);
+        }
+
+        additionalProperties.put(key, immutableValue);
+    }
+
+    /**
+     * Adds or replaces a property in the specified additional properties map that uses
+     * immutable ByteString values.
+     */
+    public static void setPropertyValueAsString(
+            @NonNull Map<String, ByteString> additionalProperties,
+            @NonNull String key,
+            @Nullable String value) {
+        setPropertyValue(additionalProperties, key,
+                AdditionalPropertiesHelper.encodeStringValue(value));
+    }
+
+    /**
+     * Copies and converts a map of additional properties that uses immutable ByteString values
+     * to one which provides raw byte[] values.
+     */
+    public static Map<String, byte[]> convertValuesToByteArrays(
+            Map<String, ByteString> additionalProperties) {
+        return CollectionConverter.convertMapValues(
+                additionalProperties,
+                ByteStringConverters.BYTE_STRING_TO_BYTE_ARRAY);
     }
 
     private AdditionalPropertiesUtil() {

--- a/protocol/javatests/org/openyolo/protocol/AdditionalPropertiesTest.java
+++ b/protocol/javatests/org/openyolo/protocol/AdditionalPropertiesTest.java
@@ -14,7 +14,8 @@
 
 package org.openyolo.protocol;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ANOTHER_KEY;
 import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_STRING_VALUE;
 import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TEST_KEY;
@@ -131,18 +132,18 @@ public class AdditionalPropertiesTest {
         assertThat(container.getAdditionalProperties()).isEmpty();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuilder_setAdditionalProperties_nullKey() {
-        new HintRetrieveRequest.Builder(AuthenticationMethods.EMAIL)
-                .setAdditionalProperties(Maps.newHashMap(null, new byte[0]))
-                .build();
+        final Map<String, byte[]> mapWithNullKey = Maps.newHashMap(null, new byte[0]);
+        assertThatThrownBy(() -> mBuilder.setAdditionalProperties(mapWithNullKey))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBuild_setAdditionalProperty_nullValue() {
-        new HintRetrieveRequest.Builder(AuthenticationMethods.EMAIL)
-                .setAdditionalProperties(Maps.newHashMap("a", null))
-                .build();
+        final Map<String, byte[]> mapWithNullValue = Maps.newHashMap("a", null);
+        assertThatThrownBy(() -> mBuilder.setAdditionalProperties(mapWithNullValue))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/protocol/javatests/org/openyolo/protocol/AdditionalPropertiesTest.java
+++ b/protocol/javatests/org/openyolo/protocol/AdditionalPropertiesTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2017 The OpenYOLO Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openyolo.protocol;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ANOTHER_KEY;
+import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_STRING_VALUE;
+import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TEST_KEY;
+import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TWO_BYTE_VALUE;
+import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ZERO_BYTE_VALUE;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import org.assertj.core.util.Maps;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openyolo.protocol.TestConstants.ValidAdditionalProperties;
+import org.openyolo.protocol.TestConstants.ValidFacebookCredential;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
+import org.robolectric.annotation.Config;
+
+/**
+ * Tests additional property storage and retrieval, for all types that implement the
+ * {@link AdditionalPropertiesContainer} interface.
+ */
+@RunWith(ParameterizedRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class AdditionalPropertiesTest {
+
+    private final String mContainerClassName;
+
+    /**
+     * Classloader shenanigans within Robolectric mean that we can't just directly instantiate
+     * and provide the instances of AdditionalPropertiesBuilder via the @Parameters annotated
+     * method. We must ensure that the instances are only created once the test methods are
+     * actually executing, as it is only at this point that the robolectric shadows have been
+     * loaded. So, as an awkward workaround, this map holds lambdas to create the builders
+     * on-demand, and the tests are parameterized by the keys of the map.
+     */
+    private static final Map<String, Callable<AdditionalPropertiesBuilder>> buildersByContainerType =
+            ImmutableMap.<String, Callable<AdditionalPropertiesBuilder>>builder()
+                    .put("Credential",
+                            () -> new Credential.Builder(
+                                    ValidFacebookCredential.ID,
+                                    ValidFacebookCredential.AUTHENTICATION_METHOD,
+                                    ValidFacebookCredential.AUTHENTICATION_DOMAIN))
+                    .put("CredentialDeleteRequest",
+                            () -> new CredentialDeleteRequest.Builder(
+                                    ValidFacebookCredential.make()))
+                    .put("CredentialDeleteResult",
+                            () -> new CredentialDeleteResult.Builder(
+                                    CredentialDeleteResult.CODE_DELETED))
+                    .put("CredentialRetrieveRequest",
+                            () -> new CredentialRetrieveRequest.Builder(
+                                    AuthenticationMethods.EMAIL))
+                    .put("CredentialRetrieveResult",
+                            () -> new CredentialRetrieveResult.Builder(
+                                    CredentialRetrieveResult.CODE_NO_CREDENTIALS_AVAILABLE))
+                    .put("CredentialSaveRequest",
+                            () -> new CredentialSaveRequest.Builder(
+                                    ValidFacebookCredential.make()))
+                    .put("CredentialSaveResult",
+                            () -> new CredentialSaveResult.Builder(
+                                    CredentialSaveResult.CODE_SAVED))
+                    .put("Hint",
+                            () -> new Hint.Builder(
+                                    ValidFacebookCredential.ID,
+                                    ValidFacebookCredential.AUTHENTICATION_METHOD))
+                    .put("HintRetrieveRequest",
+                            () -> new HintRetrieveRequest.Builder(
+                                    AuthenticationMethods.EMAIL))
+                    .put("HintRetrieveResult",
+                            () -> new HintRetrieveResult.Builder(
+                                    HintRetrieveResult.CODE_NO_HINTS_AVAILABLE))
+            .build();
+
+    @Parameters(name = "AdditionalPropertiesTest for {0}")
+    public static Collection params() {
+        ArrayList<Object[]> params = new ArrayList<>();
+
+        for (String containerTypeName : buildersByContainerType.keySet()) {
+            params.add(new Object[] { containerTypeName });
+        }
+
+        return params;
+    }
+
+    private AdditionalPropertiesBuilder<?, ?> mBuilder;
+
+    public AdditionalPropertiesTest(String containerClassName) {
+        mContainerClassName = containerClassName;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        mBuilder = buildersByContainerType.get(mContainerClassName).call();
+    }
+
+    @Test
+    public void testBuilder_setAdditionalProperties() {
+        AdditionalPropertiesContainer container = mBuilder
+                .setAdditionalProperties(ValidAdditionalProperties.make())
+                .build();
+        ValidAdditionalProperties.assertEquals(container.getAdditionalProperties());
+    }
+
+    @Test
+    public void testBuilder_setAdditionalProperties_withNull() {
+        AdditionalPropertiesContainer container = mBuilder
+                .setAdditionalProperties(ValidAdditionalProperties.make())
+                .setAdditionalProperties(null)
+                .build();
+
+        assertThat(container.getAdditionalProperties()).isEmpty();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilder_setAdditionalProperties_nullKey() {
+        new HintRetrieveRequest.Builder(AuthenticationMethods.EMAIL)
+                .setAdditionalProperties(Maps.newHashMap(null, new byte[0]))
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuild_setAdditionalProperty_nullValue() {
+        new HintRetrieveRequest.Builder(AuthenticationMethods.EMAIL)
+                .setAdditionalProperties(Maps.newHashMap("a", null))
+                .build();
+    }
+
+    @Test
+    public void testBuilder_setAdditionalProperty() {
+        AdditionalPropertiesContainer container = mBuilder
+                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE)
+                .setAdditionalProperty(ADDITIONAL_PROP_ANOTHER_KEY, ADDITIONAL_PROP_ZERO_BYTE_VALUE)
+                .build();
+
+        Map<String, byte[]> additionalProps = container.getAdditionalProperties();
+        assertThat(additionalProps.size()).isEqualTo(2);
+        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
+        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
+                .isEqualTo(ADDITIONAL_PROP_TWO_BYTE_VALUE);
+        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_ANOTHER_KEY));
+        assertThat(additionalProps.get(ADDITIONAL_PROP_ANOTHER_KEY))
+                .isEqualTo(ADDITIONAL_PROP_ZERO_BYTE_VALUE);
+    }
+
+    @Test
+    public void testBuilder_setAdditionalProperty_overwriteExistingValue() {
+        AdditionalPropertiesContainer container = mBuilder
+                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE)
+                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_ZERO_BYTE_VALUE)
+                .build();
+
+        Map<String, byte[]> additionalProps = container.getAdditionalProperties();
+        assertThat(additionalProps.size()).isEqualTo(1);
+        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
+        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
+                .isEqualTo(ADDITIONAL_PROP_ZERO_BYTE_VALUE);
+    }
+
+    @Test
+    public void testBuilder_setAdditionalPropertyAsString() {
+        AdditionalPropertiesContainer container = mBuilder
+                .setAdditionalPropertyAsString(
+                        ADDITIONAL_PROP_TEST_KEY,
+                        ADDITIONAL_PROP_STRING_VALUE)
+                .build();
+
+        Map<String, byte[]> additionalProps = container.getAdditionalProperties();
+        assertThat(additionalProps.size()).isEqualTo(1);
+        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
+        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
+                .isEqualTo(AdditionalPropertiesHelper.encodeStringValue(
+                        ADDITIONAL_PROP_STRING_VALUE));
+    }
+
+    @Test
+    public void testGetAdditionalProperty() {
+        AdditionalPropertiesContainer container = mBuilder
+                .setAdditionalProperties(ImmutableMap.of(
+                        ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE))
+                .build();
+
+        assertThat(container.getAdditionalProperty(ADDITIONAL_PROP_TEST_KEY))
+                .isEqualTo(ADDITIONAL_PROP_TWO_BYTE_VALUE);
+    }
+
+    @Test
+    public void testGetAdditionalProperty_withMissingKey() {
+        AdditionalPropertiesContainer container = mBuilder.build();
+        assertThat(container.getAdditionalProperty("missingKey")).isNull();
+    }
+
+    @Test
+    public void testGetAdditionalPropertyAsString() {
+        AdditionalPropertiesContainer container = mBuilder
+                .setAdditionalPropertyAsString(
+                        ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_STRING_VALUE)
+                .build();
+
+        assertThat(container.getAdditionalPropertyAsString(ADDITIONAL_PROP_TEST_KEY))
+                .isEqualTo(ADDITIONAL_PROP_STRING_VALUE);
+    }
+}

--- a/protocol/javatests/org/openyolo/protocol/CredentialDeleteRequestTest.java
+++ b/protocol/javatests/org/openyolo/protocol/CredentialDeleteRequestTest.java
@@ -14,19 +14,10 @@
 
 package org.openyolo.protocol;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.openyolo.protocol.AuthenticationMethods.EMAIL;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ANOTHER_KEY;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_STRING_VALUE;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TEST_KEY;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TWO_BYTE_VALUE;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ZERO_BYTE_VALUE;
 import static org.openyolo.protocol.TestConstants.INVALID_PROTO_BYTES;
 
 import android.content.Intent;
-import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
-import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openyolo.protocol.TestConstants.ValidAdditionalProperties;
@@ -71,90 +62,6 @@ public class CredentialDeleteRequestTest {
     @Test(expected = IllegalArgumentException.class)
     public void build_nullCredential_throwsIllegalArgumentException() {
         new CredentialDeleteRequest.Builder(null).build();
-    }
-
-    @Test
-    public void testBuilder_setAdditionalProperty() {
-        CredentialDeleteRequest cdr = new CredentialDeleteRequest.Builder(
-                ValidFacebookCredential.make())
-                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE)
-                .setAdditionalProperty(ADDITIONAL_PROP_ANOTHER_KEY, ADDITIONAL_PROP_ZERO_BYTE_VALUE)
-                .build();
-
-        Map<String, byte[]> additionalProps = cdr.getAdditionalProperties();
-        assertThat(additionalProps.size()).isEqualTo(2);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_TWO_BYTE_VALUE);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_ANOTHER_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_ANOTHER_KEY))
-                .isEqualTo(ADDITIONAL_PROP_ZERO_BYTE_VALUE);
-    }
-
-    @Test
-    public void testBuilder_setAdditionalProperty_overwriteExistingValue() {
-        CredentialDeleteRequest cdr = new CredentialDeleteRequest.Builder(
-                ValidFacebookCredential.make())
-                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE)
-                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_ZERO_BYTE_VALUE)
-                .build();
-
-        Map<String, byte[]> additionalProps = cdr.getAdditionalProperties();
-        assertThat(additionalProps.size()).isEqualTo(1);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_ZERO_BYTE_VALUE);
-    }
-
-    @Test
-    public void testBuilder_setAdditionalPropertyAsString() {
-        CredentialDeleteRequest cdr = new CredentialDeleteRequest.Builder(
-                ValidFacebookCredential.make())
-                .setAdditionalPropertyAsString(
-                        ADDITIONAL_PROP_TEST_KEY,
-                        ADDITIONAL_PROP_STRING_VALUE)
-                .build();
-
-        Map<String, byte[]> additionalProps = cdr.getAdditionalProperties();
-        assertThat(additionalProps.size()).isEqualTo(1);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(AdditionalPropertiesHelper.encodeStringValue(
-                        ADDITIONAL_PROP_STRING_VALUE));
-    }
-
-    @Test
-    public void testGetAdditionalProperty() {
-        CredentialDeleteRequest cdr = new CredentialDeleteRequest.Builder(
-                ValidFacebookCredential.make())
-                .setAdditionalProperties(ImmutableMap.of(
-                        ADDITIONAL_PROP_TEST_KEY,
-                        ADDITIONAL_PROP_TWO_BYTE_VALUE))
-                .build();
-
-        assertThat(cdr.getAdditionalProperty(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_TWO_BYTE_VALUE);
-    }
-
-    @Test
-    public void testGetAdditionalProperty_withMissingKey() {
-        CredentialDeleteRequest cdr = new CredentialDeleteRequest.Builder(
-                ValidFacebookCredential.make())
-                .build();
-        assertThat(cdr.getAdditionalProperty("missingKey")).isNull();
-    }
-
-    @Test
-    public void testGetAdditionalPropertyAsString() {
-        CredentialDeleteRequest cdr = new CredentialDeleteRequest.Builder(
-                ValidFacebookCredential.make())
-                .setAdditionalProperties(ImmutableMap.of(
-                        ADDITIONAL_PROP_TEST_KEY,
-                        AdditionalPropertiesHelper.encodeStringValue(ADDITIONAL_PROP_STRING_VALUE)))
-                .build();
-
-        assertThat(cdr.getAdditionalPropertyAsString(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_STRING_VALUE);
     }
 
     @Test

--- a/protocol/javatests/org/openyolo/protocol/CredentialDeleteResultTest.java
+++ b/protocol/javatests/org/openyolo/protocol/CredentialDeleteResultTest.java
@@ -15,20 +15,12 @@
 package org.openyolo.protocol;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ANOTHER_KEY;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_STRING_VALUE;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TEST_KEY;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TWO_BYTE_VALUE;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ZERO_BYTE_VALUE;
 import static org.openyolo.protocol.TestConstants.INVALID_PROTO_BYTES;
 
 import android.content.Intent;
-import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
-import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openyolo.protocol.TestConstants.ValidFacebookCredential;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -57,90 +49,6 @@ public class CredentialDeleteResultTest {
             assertThat(result.getResultCode()).isEqualTo(CredentialDeleteResult.CODE_DELETED);
             TestConstants.ValidAdditionalProperties.assertEquals(result.getAdditionalProperties());
         }
-    }
-
-    @Test
-    public void testBuilder_setAdditionalProperty() {
-        CredentialDeleteResult cdr = new CredentialDeleteResult.Builder(
-                CredentialDeleteResult.CODE_DELETED)
-                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE)
-                .setAdditionalProperty(ADDITIONAL_PROP_ANOTHER_KEY, ADDITIONAL_PROP_ZERO_BYTE_VALUE)
-                .build();
-
-        Map<String, byte[]> additionalProps = cdr.getAdditionalProperties();
-        assertThat(additionalProps.size()).isEqualTo(2);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_TWO_BYTE_VALUE);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_ANOTHER_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_ANOTHER_KEY))
-                .isEqualTo(ADDITIONAL_PROP_ZERO_BYTE_VALUE);
-    }
-
-    @Test
-    public void testBuilder_setAdditionalProperty_overwriteExistingValue() {
-        CredentialDeleteResult cdr = new CredentialDeleteResult.Builder(
-                CredentialDeleteResult.CODE_DELETED)
-                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE)
-                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_ZERO_BYTE_VALUE)
-                .build();
-
-        Map<String, byte[]> additionalProps = cdr.getAdditionalProperties();
-        assertThat(additionalProps.size()).isEqualTo(1);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_ZERO_BYTE_VALUE);
-    }
-
-    @Test
-    public void testBuilder_setAdditionalPropertyAsString() {
-        CredentialDeleteResult cdr = new CredentialDeleteResult.Builder(
-                CredentialDeleteResult.CODE_DELETED)
-                .setAdditionalPropertyAsString(
-                        ADDITIONAL_PROP_TEST_KEY,
-                        ADDITIONAL_PROP_STRING_VALUE)
-                .build();
-
-        Map<String, byte[]> additionalProps = cdr.getAdditionalProperties();
-        assertThat(additionalProps.size()).isEqualTo(1);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(AdditionalPropertiesHelper.encodeStringValue(
-                        ADDITIONAL_PROP_STRING_VALUE));
-    }
-
-    @Test
-    public void testGetAdditionalProperty() {
-        CredentialDeleteResult cdr = new CredentialDeleteResult.Builder(
-                CredentialDeleteResult.CODE_DELETED)
-                .setAdditionalProperties(ImmutableMap.of(
-                        ADDITIONAL_PROP_TEST_KEY,
-                        ADDITIONAL_PROP_TWO_BYTE_VALUE))
-                .build();
-
-        assertThat(cdr.getAdditionalProperty(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_TWO_BYTE_VALUE);
-    }
-
-    @Test
-    public void testGetAdditionalProperty_withMissingKey() {
-        CredentialDeleteResult cdr = new CredentialDeleteResult.Builder(
-                CredentialDeleteResult.CODE_DELETED)
-                .build();
-        assertThat(cdr.getAdditionalProperty("missingKey")).isNull();
-    }
-
-    @Test
-    public void testGetAdditionalPropertyAsString() {
-        CredentialDeleteResult cdr = new CredentialDeleteResult.Builder(
-                CredentialDeleteResult.CODE_DELETED)
-                .setAdditionalProperties(ImmutableMap.of(
-                        ADDITIONAL_PROP_TEST_KEY,
-                        AdditionalPropertiesHelper.encodeStringValue(ADDITIONAL_PROP_STRING_VALUE)))
-                .build();
-
-        assertThat(cdr.getAdditionalPropertyAsString(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_STRING_VALUE);
     }
 
     @Test

--- a/protocol/javatests/org/openyolo/protocol/CredentialRetrieveRequestTest.java
+++ b/protocol/javatests/org/openyolo/protocol/CredentialRetrieveRequestTest.java
@@ -18,18 +18,10 @@
 package org.openyolo.protocol;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ANOTHER_KEY;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_STRING_VALUE;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TEST_KEY;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TWO_BYTE_VALUE;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ZERO_BYTE_VALUE;
-
 
 import android.os.Parcel;
-import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,90 +55,6 @@ public class CredentialRetrieveRequestTest {
     @Test(expected = IllegalArgumentException.class)
     public void builderUriSetConstructor_withEmptySet_throwsIllegalArgumentException() {
         new CredentialRetrieveRequest.Builder(new HashSet<AuthenticationMethod>());
-    }
-
-    @Test
-    public void testBuilder_setAdditionalProperty() {
-        CredentialRetrieveRequest cdr = new CredentialRetrieveRequest.Builder(
-                AuthenticationMethods.EMAIL)
-                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE)
-                .setAdditionalProperty(ADDITIONAL_PROP_ANOTHER_KEY, ADDITIONAL_PROP_ZERO_BYTE_VALUE)
-                .build();
-
-        Map<String, byte[]> additionalProps = cdr.getAdditionalProperties();
-        assertThat(additionalProps.size()).isEqualTo(2);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_TWO_BYTE_VALUE);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_ANOTHER_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_ANOTHER_KEY))
-                .isEqualTo(ADDITIONAL_PROP_ZERO_BYTE_VALUE);
-    }
-
-    @Test
-    public void testBuilder_setAdditionalProperty_overwriteExistingValue() {
-        CredentialRetrieveRequest cdr = new CredentialRetrieveRequest.Builder(
-                AuthenticationMethods.EMAIL)
-                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE)
-                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_ZERO_BYTE_VALUE)
-                .build();
-
-        Map<String, byte[]> additionalProps = cdr.getAdditionalProperties();
-        assertThat(additionalProps.size()).isEqualTo(1);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_ZERO_BYTE_VALUE);
-    }
-
-    @Test
-    public void testBuilder_setAdditionalPropertyAsString() {
-        CredentialRetrieveRequest cdr = new CredentialRetrieveRequest.Builder(
-                AuthenticationMethods.EMAIL)
-                .setAdditionalPropertyAsString(
-                        ADDITIONAL_PROP_TEST_KEY,
-                        ADDITIONAL_PROP_STRING_VALUE)
-                .build();
-
-        Map<String, byte[]> additionalProps = cdr.getAdditionalProperties();
-        assertThat(additionalProps.size()).isEqualTo(1);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(AdditionalPropertiesHelper.encodeStringValue(
-                        ADDITIONAL_PROP_STRING_VALUE));
-    }
-
-    @Test
-    public void testGetAdditionalProperty() {
-        CredentialRetrieveRequest cdr = new CredentialRetrieveRequest.Builder(
-                AuthenticationMethods.EMAIL)
-                .setAdditionalProperties(ImmutableMap.of(
-                        ADDITIONAL_PROP_TEST_KEY,
-                        ADDITIONAL_PROP_TWO_BYTE_VALUE))
-                .build();
-
-        assertThat(cdr.getAdditionalProperty(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_TWO_BYTE_VALUE);
-    }
-
-    @Test
-    public void testGetAdditionalProperty_withMissingKey() {
-        CredentialRetrieveRequest cdr = new CredentialRetrieveRequest.Builder(
-                AuthenticationMethods.EMAIL)
-                .build();
-        assertThat(cdr.getAdditionalProperty("missingKey")).isNull();
-    }
-
-    @Test
-    public void testGetAdditionalPropertyAsString() {
-        CredentialRetrieveRequest cdr = new CredentialRetrieveRequest.Builder(
-                AuthenticationMethods.EMAIL)
-                .setAdditionalProperties(ImmutableMap.of(
-                        ADDITIONAL_PROP_TEST_KEY,
-                        AdditionalPropertiesHelper.encodeStringValue(ADDITIONAL_PROP_STRING_VALUE)))
-                .build();
-
-        assertThat(cdr.getAdditionalPropertyAsString(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_STRING_VALUE);
     }
 
     @Test(expected = MalformedDataException.class)

--- a/protocol/javatests/org/openyolo/protocol/CredentialRetrieveResultTest.java
+++ b/protocol/javatests/org/openyolo/protocol/CredentialRetrieveResultTest.java
@@ -15,14 +15,8 @@
 package org.openyolo.protocol;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ANOTHER_KEY;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_STRING_VALUE;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TEST_KEY;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TWO_BYTE_VALUE;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ZERO_BYTE_VALUE;
 
 import android.content.Intent;
-import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -97,90 +91,6 @@ public class CredentialRetrieveResultTest {
       ValidProperties.assertEqualTo(result.getAdditionalProperties());
     }
   }
-
-  @Test
-  public void testBuilder_setAdditionalProperty() {
-    CredentialRetrieveResult cdr = new CredentialRetrieveResult.Builder(
-            CredentialRetrieveResult.CODE_NO_CREDENTIALS_AVAILABLE)
-            .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE)
-            .setAdditionalProperty(ADDITIONAL_PROP_ANOTHER_KEY, ADDITIONAL_PROP_ZERO_BYTE_VALUE)
-            .build();
-
-    Map<String, byte[]> additionalProps = cdr.getAdditionalProperties();
-    assertThat(additionalProps.size()).isEqualTo(2);
-    assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-    assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-            .isEqualTo(ADDITIONAL_PROP_TWO_BYTE_VALUE);
-    assertThat(additionalProps.containsKey(ADDITIONAL_PROP_ANOTHER_KEY));
-    assertThat(additionalProps.get(ADDITIONAL_PROP_ANOTHER_KEY))
-            .isEqualTo(ADDITIONAL_PROP_ZERO_BYTE_VALUE);
-  }
-
-  @Test
-  public void testBuilder_setAdditionalProperty_overwriteExistingValue() {
-    CredentialRetrieveResult cdr = new CredentialRetrieveResult.Builder(
-            CredentialRetrieveResult.CODE_NO_CREDENTIALS_AVAILABLE)
-            .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE)
-            .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_ZERO_BYTE_VALUE)
-            .build();
-
-    Map<String, byte[]> additionalProps = cdr.getAdditionalProperties();
-    assertThat(additionalProps.size()).isEqualTo(1);
-    assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-    assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-            .isEqualTo(ADDITIONAL_PROP_ZERO_BYTE_VALUE);
-  }
-
-  @Test
-  public void testBuilder_setAdditionalPropertyAsString() {
-    CredentialRetrieveResult cdr = new CredentialRetrieveResult.Builder(
-            CredentialRetrieveResult.CODE_NO_CREDENTIALS_AVAILABLE)
-            .setAdditionalPropertyAsString(
-                    ADDITIONAL_PROP_TEST_KEY,
-                    ADDITIONAL_PROP_STRING_VALUE)
-            .build();
-
-    Map<String, byte[]> additionalProps = cdr.getAdditionalProperties();
-    assertThat(additionalProps.size()).isEqualTo(1);
-    assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-    assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-            .isEqualTo(AdditionalPropertiesHelper.encodeStringValue(
-                    ADDITIONAL_PROP_STRING_VALUE));
-  }
-
-    @Test
-    public void testGetAdditionalProperty() {
-        CredentialRetrieveResult cdr = new CredentialRetrieveResult.Builder(
-                CredentialRetrieveResult.CODE_NO_CREDENTIALS_AVAILABLE)
-                .setAdditionalProperties(ImmutableMap.of(
-                        ADDITIONAL_PROP_TEST_KEY,
-                        ADDITIONAL_PROP_TWO_BYTE_VALUE))
-                .build();
-
-        assertThat(cdr.getAdditionalProperty(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_TWO_BYTE_VALUE);
-    }
-
-    @Test
-    public void testGetAdditionalProperty_withMissingKey() {
-        CredentialRetrieveResult cdr = new CredentialRetrieveResult.Builder(
-                CredentialRetrieveResult.CODE_NO_CREDENTIALS_AVAILABLE)
-                .build();
-        assertThat(cdr.getAdditionalProperty("missingKey")).isNull();
-    }
-
-    @Test
-    public void testGetAdditionalPropertyAsString() {
-        CredentialRetrieveResult cdr = new CredentialRetrieveResult.Builder(
-                CredentialRetrieveResult.CODE_NO_CREDENTIALS_AVAILABLE)
-                .setAdditionalProperties(ImmutableMap.of(
-                        ADDITIONAL_PROP_TEST_KEY,
-                        AdditionalPropertiesHelper.encodeStringValue(ADDITIONAL_PROP_STRING_VALUE)))
-                .build();
-
-        assertThat(cdr.getAdditionalPropertyAsString(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_STRING_VALUE);
-    }
 
   @Test
   public void fromProtobufBytes_withValidCredentialSelectedResult_returnsEquivalent() throws Exception {

--- a/protocol/javatests/org/openyolo/protocol/CredentialSaveRequestTest.java
+++ b/protocol/javatests/org/openyolo/protocol/CredentialSaveRequestTest.java
@@ -151,24 +151,4 @@ public final class CredentialSaveRequestTest {
     public void builder_withNullCredential_throwsIllegalArgumentException() {
         new CredentialSaveRequest.Builder((Credential) null);
     }
-
-    public void builder_setAdditionalPropertiesWithNull_returnsEmptyMap() {
-        CredentialSaveRequest request =
-                new CredentialSaveRequest.Builder(ValidRequest.CREDENTIAL)
-                        .setAdditionalProperties(ValidRequest.ADDITIONAL_PROPERTIES)
-                        .setAdditionalProperties(null)
-                        .build();
-
-        assertThat(request.getAdditionalProperties()).isEmpty();
-    }
-
-    @Test
-    public void builder_setAdditionalProperties_isSuccessful() {
-        final CredentialSaveRequest request =
-                new CredentialSaveRequest.Builder(ValidRequest.CREDENTIAL)
-                        .setAdditionalProperties(ValidRequest.ADDITIONAL_PROPERTIES)
-                        .build();
-
-        ValidProperties.assertEqualTo(request.getAdditionalProperties());
-    }
 }

--- a/protocol/javatests/org/openyolo/protocol/CredentialSaveResultTest.java
+++ b/protocol/javatests/org/openyolo/protocol/CredentialSaveResultTest.java
@@ -95,25 +95,4 @@ public final class CredentialSaveResultTest {
     public void fromProto_withNullProto_throwsMalformedDataException() throws Exception {
         CredentialSaveResult.fromProtobuf(null);
     }
-
-    @Test
-    public void builder_setAdditionalProperties_isSuccessful() {
-        final CredentialSaveResult result =
-                new CredentialSaveResult.Builder(ValidResult.RESULT_CODE)
-                        .setAdditionalProperties(ValidResult.ADDITIONAL_PROPERTIES)
-                        .build();
-
-        ValidResult.assertEqualTo(result);
-    }
-
-    @Test
-    public void builder_setAdditionalPropertiesWithNull_isEmptyMap() {
-        CredentialSaveResult result =
-                new CredentialSaveResult.Builder(ValidResult.RESULT_CODE)
-                        .setAdditionalProperties(ValidResult.ADDITIONAL_PROPERTIES)
-                        .setAdditionalProperties(null)
-                        .build();
-
-        assertThat(result.getAdditionalProperties()).isEmpty();
-    }
 }

--- a/protocol/javatests/org/openyolo/protocol/CredentialTest.java
+++ b/protocol/javatests/org/openyolo/protocol/CredentialTest.java
@@ -17,20 +17,10 @@
 package org.openyolo.protocol;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.assertj.core.api.Java6Assertions.linesOf;
 import static org.openyolo.protocol.AuthenticationMethods.EMAIL;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ANOTHER_KEY;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_STRING_VALUE;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TEST_KEY;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_TWO_BYTE_VALUE;
-import static org.openyolo.protocol.TestConstants.ADDITIONAL_PROP_ZERO_BYTE_VALUE;
 
 import android.net.Uri;
 import android.os.Parcel;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openyolo.protocol.TestConstants.ValidFacebookCredential;
@@ -285,53 +275,6 @@ public class CredentialTest {
     }
 
     @Test
-    public void testBuilder_setAdditionalProperty() {
-        Credential cr = new Credential.Builder(EMAIL_ID, EMAIL, AUTH_DOMAIN)
-                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE)
-                .setAdditionalProperty(ADDITIONAL_PROP_ANOTHER_KEY, ADDITIONAL_PROP_ZERO_BYTE_VALUE)
-                .build();
-
-        Map<String, byte[]> additionalProps = cr.getAdditionalProperties();
-        assertThat(additionalProps.size()).isEqualTo(2);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_TWO_BYTE_VALUE);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_ANOTHER_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_ANOTHER_KEY))
-                .isEqualTo(ADDITIONAL_PROP_ZERO_BYTE_VALUE);
-    }
-
-    @Test
-    public void testBuilder_setAdditionalProperty_overwriteExistingValue() {
-        Credential cr = new Credential.Builder(EMAIL_ID, EMAIL, AUTH_DOMAIN)
-                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_TWO_BYTE_VALUE)
-                .setAdditionalProperty(ADDITIONAL_PROP_TEST_KEY, ADDITIONAL_PROP_ZERO_BYTE_VALUE)
-                .build();
-
-        Map<String, byte[]> additionalProps = cr.getAdditionalProperties();
-        assertThat(additionalProps.size()).isEqualTo(1);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(ADDITIONAL_PROP_ZERO_BYTE_VALUE);
-    }
-
-    @Test
-    public void testBuilder_setAdditionalPropertyAsString() {
-        Credential cr = new Credential.Builder(EMAIL_ID, EMAIL, AUTH_DOMAIN)
-                .setAdditionalPropertyAsString(
-                        ADDITIONAL_PROP_TEST_KEY,
-                        ADDITIONAL_PROP_STRING_VALUE)
-                .build();
-
-        Map<String, byte[]> additionalProps = cr.getAdditionalProperties();
-        assertThat(additionalProps.size()).isEqualTo(1);
-        assertThat(additionalProps.containsKey(ADDITIONAL_PROP_TEST_KEY));
-        assertThat(additionalProps.get(ADDITIONAL_PROP_TEST_KEY))
-                .isEqualTo(AdditionalPropertiesHelper.encodeStringValue(
-                        ADDITIONAL_PROP_STRING_VALUE));
-    }
-
-    @Test
     public void testGetProto() {
         Credential cr = new Credential.Builder(
                 EMAIL_ID,
@@ -371,33 +314,5 @@ public class CredentialTest {
                 .isEqualTo(cr.getDisplayPicture());
         assertThat(readCredential.getPassword())
                 .isEqualTo(cr.getPassword());
-    }
-
-    @Test
-    public void testGetAdditionalProperty() {
-        String key = "testKey";
-        byte[] value = new byte[] { 0, 1 };
-        Credential cr = new Credential.Builder(EMAIL_ID, EMAIL, AUTH_DOMAIN)
-                .setAdditionalProperties(ImmutableMap.of(key, value))
-                .build();
-
-        assertThat(cr.getAdditionalProperty(key)).isEqualTo(value);
-    }
-
-    @Test
-    public void testGetAdditionalProperty_withMissingKey() {
-        Credential cr = new Credential.Builder(EMAIL_ID, EMAIL, AUTH_DOMAIN).build();
-        assertThat(cr.getAdditionalProperty("missingKey")).isNull();
-    }
-
-    @Test
-    public void testGetAdditionalPropertyAsString() {
-        String key = "testKey";
-        byte[] value = AdditionalPropertiesHelper.encodeStringValue("testValue");
-        Credential cr = new Credential.Builder(EMAIL_ID, EMAIL, AUTH_DOMAIN)
-                .setAdditionalProperties(ImmutableMap.of(key, value))
-                .build();
-
-        assertThat(cr.getAdditionalPropertyAsString(key)).isEqualTo("testValue");
     }
 }

--- a/protocol/javatests/org/openyolo/protocol/HintRetrieveRequestTest.java
+++ b/protocol/javatests/org/openyolo/protocol/HintRetrieveRequestTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 import android.os.Parcel;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
@@ -302,25 +301,6 @@ public class HintRetrieveRequestTest {
     public void testBuild_addAuthenticationMethod_nullUri() {
         new HintRetrieveRequest.Builder(AuthenticationMethods.EMAIL)
                 .addAuthenticationMethod(null)
-                .build();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testBuild_setAdditionalProperties_nullKey() {
-        HashMap<String, byte[]> additionalProps = new HashMap<>();
-        additionalProps.put(null, new byte[0]);
-        new HintRetrieveRequest.Builder(AuthenticationMethods.EMAIL)
-                .setAdditionalProperties(additionalProps)
-                .build();
-    }
-
-    @SuppressWarnings("ConstantConditions")
-    @Test(expected = IllegalArgumentException.class)
-    public void testBuild_setAdditionalProperty_nullValue() {
-        HashMap<String, byte[]> additionalProps = new HashMap<>();
-        additionalProps.put("a", null);
-        new HintRetrieveRequest.Builder(AuthenticationMethods.EMAIL)
-                .setAdditionalProperties(additionalProps)
                 .build();
     }
 

--- a/protocol/javatests/org/openyolo/protocol/HintRetrieveResultTest.java
+++ b/protocol/javatests/org/openyolo/protocol/HintRetrieveResultTest.java
@@ -67,17 +67,6 @@ public class HintRetrieveResultTest {
     }
 
     @Test
-    public void buildSetAdditionalProperties() {
-        HintRetrieveResult result = new HintRetrieveResult.Builder(
-                HintRetrieveResult.CODE_NO_HINTS_AVAILABLE)
-                .setAdditionalProperties(ValidAdditionalProperties.make())
-                .build();
-
-        assertThat(result.getAdditionalProperties()).hasSize(1);
-        ValidAdditionalProperties.assertEquals(result.getAdditionalProperties());
-    }
-
-    @Test
     public void toProtobuf() {
         HintRetrieveResult result = new HintRetrieveResult.Builder(
                 HintRetrieveResult.CODE_HINT_SELECTED)

--- a/protocol/javatests/org/openyolo/protocol/HintTest.java
+++ b/protocol/javatests/org/openyolo/protocol/HintTest.java
@@ -100,22 +100,6 @@ public final class HintTest {
     }
 
     @Test
-    public void builderSetAdditionalProps() {
-        String additionalKey = "extra";
-        byte[] additionalValue = "value".getBytes();
-
-        Map<String, byte[]> additionalProps = new HashMap<>();
-        additionalProps.put(additionalKey, additionalValue);
-        Hint hint = new Hint.Builder(ValidEmailHint.make())
-                .setAdditionalProperties(additionalProps)
-                .build();
-
-        assertThat(hint.getAdditionalProperties()).hasSize(1);
-        assertThat(hint.getAdditionalProperties()).containsKey(additionalKey);
-        assertThat(hint.getAdditionalProperties().get(additionalKey)).isEqualTo(additionalValue);
-    }
-
-    @Test
     public void builder_withHintContructor_isEquivalent() {
         Hint hint = new Hint.Builder(ValidEmailHint.make()).build();
 


### PR DESCRIPTION
The previous changes made were introducing too much duplicate code, increasing the likelihood of inconsistent future modifications and bugs. This change refactors the implementations into the utils class, and uses parameterized unit tests to check that all implementations are consistent, without affecting the convenience of the API.

This finishes the implementation of #99.