### PR TITLE
Use explicit intents for credential retrieve

### DIFF
--- a/api/java/org/openyolo/api/internal/CredentialRetrieveActivity.java
+++ b/api/java/org/openyolo/api/internal/CredentialRetrieveActivity.java
@@ -114,9 +114,10 @@ public final class CredentialRetrieveActivity extends Activity {
                 // absence of the credentials_available field.
 
                 if (response.getCredentialsAvailable()) {
-                    Intent retrieveIntent = new Intent(
+                    Intent retrieveIntent = ProviderResolver.createIntentForAction(
+                            CredentialRetrieveActivity.this.getApplicationContext(),
+                            queryResponse.responderPackage,
                             ProtocolConstants.RETRIEVE_CREDENTIAL_ACTION);
-                    retrieveIntent.setPackage(queryResponse.responderPackage);
                     retrieveIntent.putExtra(
                             ProtocolConstants.EXTRA_RETRIEVE_REQUEST,
                             mRetrieveRequest.toProtocolBuffer().toByteArray());

--- a/api/java/org/openyolo/api/internal/ProviderResolver.java
+++ b/api/java/org/openyolo/api/internal/ProviderResolver.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 The OpenYOLO Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openyolo.api.internal;
+
+import static org.openyolo.protocol.ProtocolConstants.OPENYOLO_CATEGORY;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ResolveInfo;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility for producing OpenYOLO resolving the activities exposed by providers to handle specific,
+ * OpenYOLO actions.
+ */
+public final class ProviderResolver {
+
+    /**
+     * Creates an explicit Intent to invoke the specified action on the specified provider,
+     * if the provider has a handler registered.
+     */
+    @Nullable
+    public static Intent createIntentForAction(
+            @NonNull Context applicationContext,
+            @NonNull String providerPackageName,
+            @NonNull String action) {
+
+        ComponentName providerComponent =
+                findProvider(applicationContext, providerPackageName, action);
+
+        if (providerComponent == null) {
+            return null;
+        }
+
+        Intent intent = new Intent(action);
+        intent.setClassName(
+                providerComponent.getPackageName(),
+                providerComponent.getClassName());
+        intent.addCategory(OPENYOLO_CATEGORY);
+        return intent;
+    }
+
+    /**
+     * Resolves a {@link ComponentName} for the activity defined in the specified provider, for
+     * the specified action.
+     */
+    @Nullable
+    public static ComponentName findProvider(
+            @NonNull Context applicationContext,
+            @NonNull String providerPackageName,
+            @NonNull String action) {
+        List<ComponentName> providers = findProviders(applicationContext, action);
+
+        for (ComponentName provider : providers) {
+            if (providerPackageName.equals(provider.getPackageName())) {
+                return provider;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolves the {@link ComponentName components} for all providers which can handle the
+     * specified OpenYOLO action.
+     */
+    @NonNull
+    public static List<ComponentName> findProviders(
+            @NonNull Context applicationContext,
+            @NonNull String action) {
+        Intent saveIntent = new Intent(action);
+        saveIntent.addCategory(OPENYOLO_CATEGORY);
+
+        List<ResolveInfo> resolveInfos =
+                applicationContext.getPackageManager().queryIntentActivities(saveIntent, 0);
+
+        ArrayList<ComponentName> responders = new ArrayList<>();
+        for (ResolveInfo info : resolveInfos) {
+            responders.add(new ComponentName(
+                    info.activityInfo.packageName,
+                    info.activityInfo.name));
+        }
+
+        return responders;
+    }
+}

--- a/api/java/org/openyolo/api/internal/ProviderResolver.java
+++ b/api/java/org/openyolo/api/internal/ProviderResolver.java
@@ -31,6 +31,10 @@ import java.util.List;
  */
 public final class ProviderResolver {
 
+    private ProviderResolver() {
+        // not intended to be constructed
+    }
+
     /**
      * Creates an explicit Intent to invoke the specified action on the specified provider,
      * if the provider has a handler registered.
@@ -84,11 +88,12 @@ public final class ProviderResolver {
     public static List<ComponentName> findProviders(
             @NonNull Context applicationContext,
             @NonNull String action) {
-        Intent saveIntent = new Intent(action);
-        saveIntent.addCategory(OPENYOLO_CATEGORY);
+        Intent providerIntent = new Intent(action);
+        providerIntent.addCategory(OPENYOLO_CATEGORY);
 
         List<ResolveInfo> resolveInfos =
-                applicationContext.getPackageManager().queryIntentActivities(saveIntent, 0);
+                applicationContext.getPackageManager()
+                        .queryIntentActivities(providerIntent, 0);
 
         ArrayList<ComponentName> responders = new ArrayList<>();
         for (ResolveInfo info : resolveInfos) {

--- a/api/javatests/org/openyolo/api/internal/ProviderResolverTest.java
+++ b/api/javatests/org/openyolo/api/internal/ProviderResolverTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2017 The OpenYOLO Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.openyolo.api.internal;
+
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.ResolveInfo;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openyolo.protocol.ProtocolConstants;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowPackageManager;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class ProviderResolverTest {
+
+    private String EXAMPLE_PROVIDER_PACKAGE = "com.example.provider";
+    private String EXAMPLE_PROVIDER_ACTIVITY_CLASS = "com.example.provider.SaveActivity";
+
+    private ShadowPackageManager shadowPackageManager;
+    private Intent saveIntent;
+
+    @Before
+    public void setUp() {
+        saveIntent = new Intent(ProtocolConstants.SAVE_CREDENTIAL_ACTION);
+        saveIntent.addCategory(ProtocolConstants.OPENYOLO_CATEGORY);
+
+        shadowPackageManager =
+                Shadows.shadowOf(RuntimeEnvironment.application.getPackageManager());
+    }
+
+    @Test
+    public void findProviders_noneInstalled() {
+        List<ComponentName> providers = ProviderResolver.findProviders(
+                RuntimeEnvironment.application,
+                ProtocolConstants.SAVE_CREDENTIAL_ACTION);
+
+        assertThat(providers).isEmpty();
+    }
+
+    @Test
+    public void findProviders_singleInstalled() {
+        shadowPackageManager.addResolveInfoForIntent(
+                saveIntent,
+                createResolveInfo(EXAMPLE_PROVIDER_PACKAGE, EXAMPLE_PROVIDER_ACTIVITY_CLASS));
+
+        List<ComponentName> providers = ProviderResolver.findProviders(
+                RuntimeEnvironment.application,
+                ProtocolConstants.SAVE_CREDENTIAL_ACTION);
+
+        ComponentName expectedComponent = new ComponentName(
+                EXAMPLE_PROVIDER_PACKAGE,
+                EXAMPLE_PROVIDER_ACTIVITY_CLASS);
+        assertThat(providers).containsExactly(expectedComponent);
+    }
+
+    @Test
+    public void findProvider_matchingPackage() {
+        shadowPackageManager.addResolveInfoForIntent(
+                saveIntent,
+                createResolveInfo(EXAMPLE_PROVIDER_PACKAGE, EXAMPLE_PROVIDER_ACTIVITY_CLASS));
+
+        ComponentName provider = ProviderResolver.findProvider(
+                RuntimeEnvironment.application,
+                EXAMPLE_PROVIDER_PACKAGE,
+                ProtocolConstants.SAVE_CREDENTIAL_ACTION);
+
+        assertThat(provider).isNotNull();
+        assertThat(provider.getPackageName()).isEqualTo(EXAMPLE_PROVIDER_PACKAGE);
+        assertThat(provider.getClassName()).isEqualTo(EXAMPLE_PROVIDER_ACTIVITY_CLASS);
+    }
+
+    @Test
+    public void findProvider_nonMatchingPackage() {
+        shadowPackageManager.addResolveInfoForIntent(
+                saveIntent,
+                createResolveInfo(EXAMPLE_PROVIDER_PACKAGE, EXAMPLE_PROVIDER_ACTIVITY_CLASS));
+
+        ComponentName provider = ProviderResolver.findProvider(
+                RuntimeEnvironment.application,
+                "com.different.provider",
+                ProtocolConstants.SAVE_CREDENTIAL_ACTION);
+
+        assertThat(provider).isNull();
+    }
+
+    @Test
+    public void createIntentForAction_matchingPackage() {
+        shadowPackageManager.addResolveInfoForIntent(
+                saveIntent,
+                createResolveInfo(EXAMPLE_PROVIDER_PACKAGE, EXAMPLE_PROVIDER_ACTIVITY_CLASS));
+
+        Intent intentForAction = ProviderResolver.createIntentForAction(
+                RuntimeEnvironment.application,
+                EXAMPLE_PROVIDER_PACKAGE,
+                ProtocolConstants.SAVE_CREDENTIAL_ACTION);
+
+        assertThat(intentForAction).isNotNull();
+        assertThat(intentForAction.getAction())
+                .isEqualTo(ProtocolConstants.SAVE_CREDENTIAL_ACTION);
+        assertThat(intentForAction.getCategories())
+                .containsExactly(ProtocolConstants.OPENYOLO_CATEGORY);
+        assertThat(intentForAction.getComponent()).isNotNull();
+        assertThat(intentForAction.getComponent().getPackageName())
+                .isEqualTo(EXAMPLE_PROVIDER_PACKAGE);
+        assertThat(intentForAction.getComponent().getClassName())
+                .isEqualTo(EXAMPLE_PROVIDER_ACTIVITY_CLASS);
+    }
+
+    @Test
+    public void createIntentForAction_nonMatchingPackage() {
+        shadowPackageManager.addResolveInfoForIntent(
+                saveIntent,
+                createResolveInfo(EXAMPLE_PROVIDER_PACKAGE, EXAMPLE_PROVIDER_ACTIVITY_CLASS));
+
+        Intent intentForAction = ProviderResolver.createIntentForAction(
+                RuntimeEnvironment.application,
+                "com.different.provider",
+                ProtocolConstants.SAVE_CREDENTIAL_ACTION);
+
+        assertThat(intentForAction).isNull();
+    }
+
+    private ResolveInfo createResolveInfo(String packageName, String activityClass) {
+        ResolveInfo resolveInfo = new ResolveInfo();
+        resolveInfo.activityInfo = new ActivityInfo();
+        resolveInfo.activityInfo.packageName = packageName;
+        resolveInfo.activityInfo.name = activityClass;
+
+        return resolveInfo;
+    }
+}


### PR DESCRIPTION
@nerdyverde helped in finding a bug with the current client-side intent construction that was introduced in 0.3.0 - explicit intents are required when targeting a specific package, so the approach included in 0.3.0 was breaking when providers migrated to the new response type.