### PR TITLE
Increase timeout for providers, add new timeout status code

### DIFF
--- a/api/java/org/openyolo/api/internal/CredentialRetrieveActivity.java
+++ b/api/java/org/openyolo/api/internal/CredentialRetrieveActivity.java
@@ -47,6 +47,11 @@ public final class CredentialRetrieveActivity extends Activity {
     private static final String LOG_TAG = "CredentialRetrieveAct";
     private static final String EXTRA_REQUEST = "Request";
 
+    // The amount of time we will permit providers to "think" about responding to a retrieve
+    // BBQ request. The default BBQ timeout of two seconds proved to be too short when the device
+    // is actively updating and compiling apps, so we extend it here.
+    private static final long RETRIEVE_TIMEOUT_MS = 4000;
+
     private boolean mIsDestroyed = false;
 
     /**
@@ -77,6 +82,7 @@ public final class CredentialRetrieveActivity extends Activity {
                 .queryFor(
                         CREDENTIAL_DATA_TYPE,
                         request.toProtocolBuffer(),
+                        RETRIEVE_TIMEOUT_MS,
                         new CredentialRetrieveQueryCallback(request));
     }
 
@@ -143,8 +149,8 @@ public final class CredentialRetrieveActivity extends Activity {
 
             if (retrieveIntents.isEmpty()) {
                 setResult(
-                        CredentialRetrieveResult.CODE_UNKNOWN,
-                        CredentialRetrieveResult.UNKNOWN.toResultDataIntent());
+                        CredentialRetrieveResult.CODE_PROVIDER_TIMEOUT,
+                        CredentialRetrieveResult.PROVIDER_TIMEOUT.toResultDataIntent());
                 finish();
                 return;
             }

--- a/protocol/java/org/openyolo/protocol/CredentialRetrieveResult.java
+++ b/protocol/java/org/openyolo/protocol/CredentialRetrieveResult.java
@@ -84,6 +84,13 @@ public final class CredentialRetrieveResult implements AdditionalPropertiesConta
             Protobufs.CredentialRetrieveResult.ResultCode.USER_CANCELED_VALUE;
 
     /**
+     * Indicates that the provider(s) failed to respond in a timely manner. This error is usually
+     * transient, and due to the device being presently CPU-bound.
+     */
+    public static final int CODE_PROVIDER_TIMEOUT =
+            Protobufs.CredentialRetrieveResult.ResultCode.PROVIDER_TIMEOUT_VALUE;
+
+    /**
      * Pre-built result that indicates that the provider returned a response that could not be
      * interpreted.
      */
@@ -122,6 +129,13 @@ public final class CredentialRetrieveResult implements AdditionalPropertiesConta
      */
     public static final CredentialRetrieveResult USER_CANCELED =
             new CredentialRetrieveResult.Builder(CODE_USER_CANCELED).build();
+
+    /**
+     * Pre-built result that indicates that the provider(s) failed to respond in a timely manner.
+     * This error is usually transient, and due to the device being presently CPU-bound.
+     */
+    public static final CredentialRetrieveResult PROVIDER_TIMEOUT =
+            new CredentialRetrieveResult.Builder(CODE_PROVIDER_TIMEOUT).build();
 
     /**
      * Creates a credential retrieve result from its protocol buffer byte equivalent.

--- a/protocol/proto/openyolo.proto
+++ b/protocol/proto/openyolo.proto
@@ -83,6 +83,7 @@ message CredentialRetrieveResult {
         USER_REQUESTS_MANUAL_AUTH = 4;
         USER_CANCELED = 5;
         NO_PROVIDER_AVAILABLE = 6;
+        PROVIDER_TIMEOUT = 7;
     }
 
     // required


### PR DESCRIPTION
During testing with @nerdyverde we noticed that if the device is busy (such as
installing app updates) that the two second timeout is often insufficient, resulting
in failure to retrieve. This PR boosts the timeout to 4 seconds, and introduces
an explicit timeout error code to make it easier to understand when this happens.