### PR TITLE
Fix minor issues in password login demo app

### DIFF
--- a/demoapps/passwordlogin/java/org/openyolo/demoapp/passwordlogin/DataBindingAdapters.java
+++ b/demoapps/passwordlogin/java/org/openyolo/demoapp/passwordlogin/DataBindingAdapters.java
@@ -16,7 +16,9 @@ package org.openyolo.demoapp.passwordlogin;
 
 import android.databinding.BindingAdapter;
 import android.support.design.widget.TextInputLayout;
+import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.TextView;
 
 /**
  * Android data binding extensions which make facilitate binding to more advanced field types.
@@ -42,5 +44,15 @@ public final class DataBindingAdapters {
     @BindingAdapter("errorText")
     public static void setErrorText(TextInputLayout layout, String errorText) {
         layout.setError(errorText);
+    }
+
+    /**
+     * Facilitates binding editor action listeners on EditText fields.
+     */
+    @BindingAdapter("onEditorAction")
+    public static void setOnEditorActionListener(
+            EditText layout,
+            TextView.OnEditorActionListener listener) {
+        layout.setOnEditorActionListener(listener);
     }
 }

--- a/demoapps/passwordlogin/res/drawable/rect_border_grey_300.xml
+++ b/demoapps/passwordlogin/res/drawable/rect_border_grey_300.xml
@@ -1,0 +1,6 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke
+        android:width="1dp"
+        android:color="@color/grey_300_opaque" />
+</shape>

--- a/demoapps/passwordlogin/res/drawable/rounded_rect_border_grey_500.xml
+++ b/demoapps/passwordlogin/res/drawable/rounded_rect_border_grey_500.xml
@@ -1,0 +1,8 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners
+        android:radius="6dp" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/grey_500_opaque" />
+</shape>

--- a/demoapps/passwordlogin/res/layout/login_layout.xml
+++ b/demoapps/passwordlogin/res/layout/login_layout.xml
@@ -17,7 +17,9 @@
       android:id="@+id/contentFrame"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      tools:context=".LoginActivity">
+      android:importantForAutofill="noExcludeDescendants"
+      tools:context=".LoginActivity"
+      tools:ignore="UnusedAttribute">
 
     <LinearLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
@@ -91,7 +93,9 @@
               android:layout_height="wrap_content"
               android:hint="@string/email_field_hint"
               android:inputType="textEmailAddress"
-              android:text="@={viewmodel.email}"/>
+              android:text="@={viewmodel.email}"
+              android:imeOptions="actionNext"
+              app:onEditorAction="@{viewmodel.editorActionListener}"/>
 
         </android.support.design.widget.TextInputLayout>
 
@@ -109,7 +113,9 @@
               android:layout_height="wrap_content"
               android:text="@={viewmodel.password}"
               android:inputType="textPassword"
-              android:hint="@string/password_field_hint" />
+              android:hint="@string/password_field_hint"
+              android:imeOptions="actionDone"
+              app:onEditorAction="@{viewmodel.editorActionListener}" />
 
         </android.support.design.widget.TextInputLayout>
 
@@ -118,7 +124,7 @@
             android:layout_height="72dp"
             android:layout_gravity="center"
             android:layout_margin="8dp"
-            android:onClick="@{viewmodel::signInButtonClicked}"
+            android:onClick="@{viewmodel::processAction}"
             app:srcCompat="@drawable/ic_done" />
 
         <TextView

--- a/demoapps/passwordlogin/res/layout/main_layout.xml
+++ b/demoapps/passwordlogin/res/layout/main_layout.xml
@@ -41,17 +41,24 @@
           android:text="@string/signed_in_prompt"/>
 
       <LinearLayout
-          android:layout_width="match_parent"
+          android:layout_marginTop="8dp"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:padding="16dp"
-          android:orientation="horizontal">
+          android:paddingTop="8dp"
+          android:paddingBottom="8dp"
+          android:paddingLeft="12dp"
+          android:paddingRight="12dp"
+          android:orientation="horizontal"
+          android:layout_gravity="center"
+          android:background="@drawable/rounded_rect_border_grey_500">
 
         <ImageView
             android:id="@+id/profile_picture"
             android:layout_width="64dp"
             android:layout_height="64dp"
             android:src="@{viewmodel.displayPicture}"
-            android:contentDescription="@string/user_profile_picture"/>
+            android:contentDescription="@string/user_profile_picture"
+            android:background="@drawable/rect_border_grey_300"/>
 
         <LinearLayout
             android:layout_width="0dp"
@@ -59,19 +66,22 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
             android:layout_marginLeft="8dp"
-            android:orientation="horizontal">
+            android:layout_gravity="center_vertical"
+            android:orientation="vertical">
 
           <TextView
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
-              android:text="@{viewmodel.displayName}"/>
+              android:text="@{viewmodel.displayName}"
+              tools:text="John Doe"/>
 
           <TextView
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-              android:text="@{viewmodel.email}"/>
+              android:text="@{viewmodel.email}"
+              tools:text="jdoe@example.com"/>
         </LinearLayout>
 
       </LinearLayout>

--- a/demoapps/passwordlogin/res/values/colors.xml
+++ b/demoapps/passwordlogin/res/values/colors.xml
@@ -3,4 +3,6 @@
   <color name="colorPrimary">#2491eb</color>
   <color name="colorPrimaryDark">#36434f</color>
   <color name="colorAccent">#4fc3f7</color>
+  <color name="grey_300_opaque">#e0e0e0</color>
+  <color name="grey_500_opaque">#9e9e9e</color>
 </resources>

--- a/demoapps/passwordlogin/res/values/strings.xml
+++ b/demoapps/passwordlogin/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="app_name_short">OpenYOLO</string>
+  <string name="app_name_short">Pwd Demo</string>
   <string name="email_field_hint">Email</string>
   <string name="password_field_hint">Password</string>
   <string name="login_header">OpenYOLO Demo - Password Login</string>
@@ -13,9 +13,9 @@
   <string name="error_prompt">Oops, that didn\'t work. Maybe try again?</string>
   <string name="signed_in_prompt">You are signed in as:</string>
   <string name="error_invalid_email">Invalid email address</string>
-  <string name="error_password_too_short">Password is too short</string>
   <string name="error_incorrect_password">Wrong password, please try again</string>
   <string name="user_profile_picture">User profile picture</string>
   <string name="existing_account_search_prompt">Looking for an existing account…</string>
   <string name="requesting_hint_prompt">Asking your credential manager for account details…</string>
+    <string name="no_display_name">[ no display name ]</string>
 </resources>


### PR DESCRIPTION
- Remove password length checking as a short-term fix for bad state handling in LoginViewModel
- Disable auto-fill in the login activity
- Render signed in account information in more detail in the main view
- Disable automatic sign-in when signing out
- Other things I did during DroidCon and likely forgot.